### PR TITLE
fix crash with deleting cell, also fix scroll(to:Edge

### DIFF
--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -230,9 +230,8 @@ open class CollectionView: UIScrollView {
   private func _deleteCell(at: Int) {
     let identifier = visibleIdentifiers.remove(at: at)
     let cell = identifierToView[identifier]!
-    let index = identifierToIndex[identifier]!
     identifierToView[identifier] = nil
-    (cell.currentCollectionPresenter ?? presenter).delete(collectionView: self, view: cell, at: index)
+    (cell.currentCollectionPresenter ?? presenter).delete(collectionView: self, view: cell)
   }
 
   private func _moveCell(from: Int, to: Int) {

--- a/Sources/Extensions/UIScrollView+CollectionKit.swift
+++ b/Sources/Extensions/UIScrollView+CollectionKit.swift
@@ -30,19 +30,19 @@ extension UIScrollView {
     return point - contentOffset
   }
   public func scrollTo(edge: UIRectEdge, animated: Bool) {
-    let target: CGRect
+    let target:CGPoint
     switch edge {
     case UIRectEdge.top:
-      target = CGRect(x: contentOffset.x, y: offsetFrame.minY, width: 1, height: 1)
+      target = CGPoint(x: contentOffset.x, y: offsetFrame.minY)
     case UIRectEdge.bottom:
-      target = CGRect(x: contentOffset.x, y: offsetFrame.maxY - 1, width: 1, height: 1)
+      target = CGPoint(x: contentOffset.x, y: offsetFrame.maxY)
     case UIRectEdge.left:
-      target = CGRect(x: offsetFrame.minX, y: contentOffset.y, width: 1, height: 1)
+      target = CGPoint(x: offsetFrame.minX, y: contentOffset.y)
     case UIRectEdge.right:
-      target = CGRect(x: offsetFrame.maxX - 1, y: contentOffset.y, width: 1, height: 1)
+      target = CGPoint(x: offsetFrame.maxY, y: contentOffset.y)
     default:
       return
     }
-    scrollRectToVisible(target, animated: animated)
+    setContentOffset(target, animated: true)
   }
 }

--- a/Sources/Presenter/CollectionPresenter.swift
+++ b/Sources/Presenter/CollectionPresenter.swift
@@ -38,7 +38,7 @@ open class CollectionPresenter {
       }
     }
   }
-  open func delete(collectionView: CollectionView, view: UIView, at: Int) {
+  open func delete(collectionView: CollectionView, view: UIView) {
     if collectionView.reloading, collectionView.bounds.intersects(view.frame), let deleteAnimation = deleteAnimation {
       switch deleteAnimation {
       case .fade:


### PR DESCRIPTION
Fix the crash with deleting cell where the identifier might not be in `identifierToIndex` anymore.
This is done by removing the `index` property for `CollectionPresenter.delete(colletionView:, view:, at:)`

Also fix the implementation of `scroll(to:Edge)`