### PR TITLE
not treat non-visible edge cells as visible

### DIFF
--- a/CollectionKitTests/FlowLayoutSpec.swift
+++ b/CollectionKitTests/FlowLayoutSpec.swift
@@ -45,6 +45,13 @@ class FlowLayoutSpec: QuickSpec {
         layout.mockLayout(parentSize: (130, 130), (50, 50), (50, 50), (50, 50))
         expect(layout.frames).to(equal(frames((0, 0, 50, 50), (60, 0, 50, 50), (0, 60, 50, 50))))
       }
+
+      it("should not display cells outside of the visible area") {
+        let layout = FlowLayout<CGSize>().transposed()
+        layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
+        let visible = layout.visibleIndexes(activeFrame: CGRect(x: 50, y: 0, width: 100, height: 50))
+        expect(visible).to(equal([1, 2]))
+      }
     }
   }
 }

--- a/Sources/Layout/SimpleLayout.swift
+++ b/Sources/Layout/SimpleLayout.swift
@@ -64,10 +64,10 @@ open class VerticalSimpleLayout<Data>: SimpleLayout<Data> {
     var visibleIndexes = [Int]()
     while index < frames.count {
       let frame = frames[index]
-      if frame.minY > activeFrame.maxY {
+      if frame.minY >= activeFrame.maxY {
         break
       }
-      if frame.maxY >= activeFrame.minY {
+      if frame.maxY > activeFrame.minY {
         visibleIndexes.append(index)
       }
       index += 1
@@ -88,10 +88,10 @@ open class HorizontalSimpleLayout<Data>: SimpleLayout<Data> {
     var visibleIndexes = [Int]()
     while index < frames.count {
       let frame = frames[index]
-      if frame.minX > activeFrame.maxX {
+      if frame.minX >= activeFrame.maxX {
         break
       }
-      if frame.maxX >= activeFrame.minX {
+      if frame.maxX > activeFrame.minX {
         visibleIndexes.append(index)
       }
       index += 1


### PR DESCRIPTION
This fix an edge case when cell is on the edge but just outside of the visible area, collection kit treat it as visible which cause the cell to be loaded. But in some performance context this might not be the behaviour users want. 