### PR TITLE
remove an unnecessary update call

### DIFF
--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -236,7 +236,6 @@ open class CollectionView: UIScrollView {
     let frame = provider.frame(at: index)
     cell.bounds.size = frame.bounds.size
     cell.center = frame.center
-    provider.update(view: cell, at: index)
     cell.currentCollectionPresenter = cell.collectionPresenter ?? provider.presenter(at: index)
     let presenter = cell.currentCollectionPresenter ?? self.presenter
     presenter.insert(collectionView: self, view: cell, at: index, frame: provider.frame(at: index))


### PR DESCRIPTION
When inserting a cell, CollectionView does an update on the cell before it insert the cell into the view hierarchy. This is not really necessary since CollectionViewProvider does this before returning the cell. For custom view provider, we want to delegate this responsibility to the user writing the custom view provider. 