### PR TITLE
Convert the Convenience Inits to designated Inits to use them for subclassing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To build a basic provider, here is what you need:
 ```swift
 let provider1 = CollectionProvider(
     data: [1，2，3, 4], // provide an array of data, data can be any type
-    viewUpdater: { (label: UILabel, index: Int, data: Int) in
+    viewUpdater: { (label: UILabel, data: Int, index: Int) in
         // update your view according to your data, view can be any subclass of UIView
         label.backgroundColor = .red
         label.layer.cornerRadius = 8
@@ -105,7 +105,7 @@ provider1.layout = FlowLayout(spacing: 10)
 
 let provider2 = CollectionProvider(
     data: ["A", "B"],
-    viewUpdater: { (label: UILabel, index: Int, data: String) in
+    viewUpdater: { (label: UILabel, data: String, index: Int) in
         label.backgroundColor = .blue
         label.layer.cornerRadius = 8
         label.textAlignment = .center

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -50,46 +50,48 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     super.init(identifier: identifier)
   }
 
-  public convenience init(identifier: String? = nil,
-                          dataProvider: DataProvider,
-                          viewGenerator: ((Data, Int) -> View)? = nil,
-                          viewUpdater: @escaping (View, Data, Int) -> Void,
-                          layout: Layout = FlowLayout<Data>(),
-                          sizeProvider: @escaping SizeProvider = defaultSizeProvider,
-                          presenter: Presenter? = nil,
-                          willReloadHandler: (() -> Void)? = nil,
-                          didReloadHandler: (() -> Void)? = nil,
-                          tapHandler: TapHandler? = nil) {
-    self.init(identifier: identifier,
-              dataProvider: dataProvider,
-              viewProvider: ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater),
-              layout: layout,
-              sizeProvider: sizeProvider,
-              presenter: presenter,
-              willReloadHandler: willReloadHandler,
-              didReloadHandler: didReloadHandler,
-              tapHandler: tapHandler)
+  public init(identifier: String? = nil,
+              dataProvider: DataProvider,
+              viewGenerator: ((Data, Int) -> View)? = nil,
+              viewUpdater: @escaping (View, Data, Int) -> Void,
+              layout: Layout = FlowLayout<Data>(),
+              sizeProvider: @escaping SizeProvider = defaultSizeProvider,
+              presenter: Presenter? = nil,
+              willReloadHandler: (() -> Void)? = nil,
+              didReloadHandler: (() -> Void)? = nil,
+              tapHandler: TapHandler? = nil) {
+    
+    self.dataProvider = dataProvider
+    self.viewProvider = ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater)
+    self.layout = layout
+    self.sizeProvider = sizeProvider
+    self.presenter = presenter
+    self.willReloadHandler = willReloadHandler
+    self.didReloadHandler = didReloadHandler
+    self.tapHandler = tapHandler
+    super.init(identifier: identifier)
   }
 
-  public convenience init(identifier: String? = nil,
-                          data: [Data],
-                          viewGenerator: ((Data, Int) -> View)? = nil,
-                          viewUpdater: @escaping (View, Data, Int) -> Void,
-                          layout: Layout = FlowLayout<Data>(),
-                          sizeProvider: @escaping SizeProvider = defaultSizeProvider,
-                          presenter: Presenter? = nil,
-                          willReloadHandler: (() -> Void)? = nil,
-                          didReloadHandler: (() -> Void)? = nil,
-                          tapHandler: TapHandler? = nil) {
-    self.init(identifier: identifier,
-              dataProvider: ArrayDataProvider(data: data),
-              viewProvider: ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater),
-              layout: layout,
-              sizeProvider: sizeProvider,
-              presenter: presenter,
-              willReloadHandler: willReloadHandler,
-              didReloadHandler: didReloadHandler,
-              tapHandler: tapHandler)
+  public init(identifier: String? = nil,
+              data: [Data],
+              viewGenerator: ((Data, Int) -> View)? = nil,
+              viewUpdater: @escaping (View, Data, Int) -> Void,
+              layout: Layout = FlowLayout<Data>(),
+              sizeProvider: @escaping SizeProvider = defaultSizeProvider,
+              presenter: Presenter? = nil,
+              willReloadHandler: (() -> Void)? = nil,
+              didReloadHandler: (() -> Void)? = nil,
+              tapHandler: TapHandler? = nil) {
+    
+    self.dataProvider = ArrayDataProvider(data: data)
+    self.viewProvider = ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater)
+    self.layout = layout
+    self.sizeProvider = sizeProvider
+    self.presenter = presenter
+    self.willReloadHandler = willReloadHandler
+    self.didReloadHandler = didReloadHandler
+    self.tapHandler = tapHandler
+    super.init(identifier: identifier)
   }
 
   // MARK: - Override Methods

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -60,7 +60,6 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
               willReloadHandler: (() -> Void)? = nil,
               didReloadHandler: (() -> Void)? = nil,
               tapHandler: TapHandler? = nil) {
-    
     self.dataProvider = dataProvider
     self.viewProvider = ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater)
     self.layout = layout
@@ -82,7 +81,6 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
               willReloadHandler: (() -> Void)? = nil,
               didReloadHandler: (() -> Void)? = nil,
               tapHandler: TapHandler? = nil) {
-    
     self.dataProvider = ArrayDataProvider(data: data)
     self.viewProvider = ClosureViewProvider(viewGenerator: viewGenerator, viewUpdater: viewUpdater)
     self.layout = layout


### PR DESCRIPTION
I tried to subclass the CollectionProvider today and got an error that I can't use the convenience Inits (like used in the documentation) for subclassing.

My proposal is to convert the convenience inits to designated inits. Sadly simply removing the convenience mark resulted in an error:
````
Designated initializer for cannot ... delegate (with 'self.init')
````

I know that simply duplicating code isn't really helpful so if someone has a better solution to make those Inits subclassable, you'r welcome :) 