### PR TITLE
Next version of CollectionKit (v2.0.0), first PR

### DIFF
--- a/CollectionKit.podspec
+++ b/CollectionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CollectionKit"
-  s.version          = "1.3.0"
+  s.version          = "2.0.0"
   s.summary          = "A modern swift framework for building data-driven reusable collection view components."
 
   s.description      = <<-DESC

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		A3299F342064ED690075A137 /* VisibleFrameInsetLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3299F332064ED690075A137 /* VisibleFrameInsetLayout.swift */; };
 		A363C56520C7EA44009A885F /* ViewProviderComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56420C7EA44009A885F /* ViewProviderComposer.swift */; };
 		A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */; };
+		A363C56A20C955C7009A885F /* LayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56920C955C7009A885F /* LayoutContext.swift */; };
 		A372A3691C79567A0023C797 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A372A3681C79567A0023C797 /* MessageCell.swift */; };
 		A3DDEECF1C7D88430053BFAE /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DDEECE1C7D88430053BFAE /* Messages.swift */; };
 		A3FC21C81C6EE5AA008566BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC21C71C6EE5AA008566BB /* AppDelegate.swift */; };
@@ -134,6 +135,7 @@
 		A351C3461CE4CCD2005E15A7 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewProvider.swift; sourceTree = "<group>"; };
 		A363C56420C7EA44009A885F /* ViewProviderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewProviderComposer.swift; sourceTree = "<group>"; };
+		A363C56920C955C7009A885F /* LayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutContext.swift; sourceTree = "<group>"; };
 		A372A3681C79567A0023C797 /* MessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
 		A3DDEECE1C7D88430053BFAE /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A3FC21C41C6EE5AA008566BB /* CollectionKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollectionKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -378,6 +380,7 @@
 			children = (
 				B144CDFF1F4379DA0073CF4E /* ClosureLayout.swift */,
 				B1E861F51F21518700621BA0 /* CollectionLayout.swift */,
+				A363C56920C955C7009A885F /* LayoutContext.swift */,
 				B1ED75B41F58C95200CB772A /* FloatLayout.swift */,
 				B144CE031F437A100073CF4E /* FlowLayout.swift */,
 				B183C11F1F6349B800CEAAE1 /* InsetLayout.swift */,
@@ -745,6 +748,7 @@
 				B144CE021F4379F20073CF4E /* WaterfallLayout.swift in Sources */,
 				B144CE151F437AC10073CF4E /* ZoomPresenter.swift in Sources */,
 				B183C11E1F63218E00CEAAE1 /* LayoutHelper.swift in Sources */,
+				A363C56A20C955C7009A885F /* LayoutContext.swift in Sources */,
 				B1E861F71F21519900621BA0 /* CollectionLayout.swift in Sources */,
 				B14B0E061F2790E6003E5105 /* CollectionReloadable.swift in Sources */,
 				B148237C1F1E88430007A7E2 /* CollectionProvider.swift in Sources */,

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A363C56C20CACA8A009A885F /* FlattenedProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56B20CACA89009A885F /* FlattenedProvider.swift */; };
 		A363C56E20CBD55B009A885F /* CollectionHeaderComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56D20CBD55B009A885F /* CollectionHeaderComposer.swift */; };
 		A363C57020CBF6A1009A885F /* HeaderExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56F20CBF6A1009A885F /* HeaderExampleViewController.swift */; };
+		A363C57320CC015D009A885F /* SquareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C57220CC015D009A885F /* SquareView.swift */; };
 		A372A3691C79567A0023C797 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A372A3681C79567A0023C797 /* MessageCell.swift */; };
 		A3DDEECF1C7D88430053BFAE /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DDEECE1C7D88430053BFAE /* Messages.swift */; };
 		A3FC21C81C6EE5AA008566BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC21C71C6EE5AA008566BB /* AppDelegate.swift */; };
@@ -142,6 +143,7 @@
 		A363C56B20CACA89009A885F /* FlattenedProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlattenedProvider.swift; sourceTree = "<group>"; };
 		A363C56D20CBD55B009A885F /* CollectionHeaderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionHeaderComposer.swift; sourceTree = "<group>"; };
 		A363C56F20CBF6A1009A885F /* HeaderExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HeaderExampleViewController.swift; path = Examples/HeaderExample/HeaderExampleViewController.swift; sourceTree = SOURCE_ROOT; };
+		A363C57220CC015D009A885F /* SquareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SquareView.swift; sourceTree = "<group>"; };
 		A372A3681C79567A0023C797 /* MessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
 		A3DDEECE1C7D88430053BFAE /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A3FC21C41C6EE5AA008566BB /* CollectionKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollectionKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -304,6 +306,7 @@
 				A3FC21D31C6EE5AA008566BB /* Info.plist */,
 				A3FC21D01C6EE5AA008566BB /* LaunchScreen.storyboard */,
 				B100C3F71EA55A9400868840 /* DynamicView.swift */,
+				A363C57220CC015D009A885F /* SquareView.swift */,
 				B102FC5C1D10FF5100408DD6 /* Random.swift */,
 				B100C3FB1EA55DB500868840 /* Util.swift */,
 			);
@@ -705,6 +708,7 @@
 				B102FC5D1D10FF5100408DD6 /* Random.swift in Sources */,
 				B1688A271F25448900C229BD /* ViewController.swift in Sources */,
 				B145FFA61F5DF60300A4F318 /* CollectionViewController.swift in Sources */,
+				A363C57320CC015D009A885F /* SquareView.swift in Sources */,
 				B1A073701F438A3500E28E23 /* EdgeShrinkPresenter.swift in Sources */,
 				A363C57020CBF6A1009A885F /* HeaderExampleViewController.swift in Sources */,
 				B14ABA2D1FE2F59B005D889A /* ReloadAnimationViewController.swift in Sources */,

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -84,7 +84,7 @@
 		B1E861F41F21517400621BA0 /* CollectionDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E861F21F21516E00621BA0 /* CollectionDataProvider.swift */; };
 		B1E861F71F21519900621BA0 /* CollectionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E861F51F21518700621BA0 /* CollectionLayout.swift */; };
 		B1E861F91F21520200621BA0 /* CollectionComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E861F81F21520200621BA0 /* CollectionComposer.swift */; };
-		B1ED75B51F58C95200CB772A /* FloatLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ED75B41F58C95200CB772A /* FloatLayout.swift */; };
+		B1ED75B51F58C95200CB772A /* StickyLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1ED75B41F58C95200CB772A /* StickyLayout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -208,7 +208,7 @@
 		B1E861F21F21516E00621BA0 /* CollectionDataProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionDataProvider.swift; sourceTree = "<group>"; };
 		B1E861F51F21518700621BA0 /* CollectionLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionLayout.swift; sourceTree = "<group>"; };
 		B1E861F81F21520200621BA0 /* CollectionComposer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionComposer.swift; sourceTree = "<group>"; };
-		B1ED75B41F58C95200CB772A /* FloatLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatLayout.swift; sourceTree = "<group>"; };
+		B1ED75B41F58C95200CB772A /* StickyLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickyLayout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -396,7 +396,7 @@
 				B144CDFF1F4379DA0073CF4E /* ClosureLayout.swift */,
 				B1E861F51F21518700621BA0 /* CollectionLayout.swift */,
 				A363C56920C955C7009A885F /* LayoutContext.swift */,
-				B1ED75B41F58C95200CB772A /* FloatLayout.swift */,
+				B1ED75B41F58C95200CB772A /* StickyLayout.swift */,
 				B144CE031F437A100073CF4E /* FlowLayout.swift */,
 				B183C11F1F6349B800CEAAE1 /* InsetLayout.swift */,
 				A3299F332064ED690075A137 /* VisibleFrameInsetLayout.swift */,
@@ -748,7 +748,7 @@
 				A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */,
 				B144CE0D1F437A960073CF4E /* ArrayDataProvider.swift in Sources */,
 				B14B0E021F2682EA003E5105 /* CollectionSizeProvider.swift in Sources */,
-				B1ED75B51F58C95200CB772A /* FloatLayout.swift in Sources */,
+				B1ED75B51F58C95200CB772A /* StickyLayout.swift in Sources */,
 				B183C1201F6349B800CEAAE1 /* InsetLayout.swift in Sources */,
 				B1B725991F671E2B007AC38C /* WrapperLayout.swift in Sources */,
 				B14B0DFD1F2679E7003E5105 /* UIView+CollectionKit.swift in Sources */,

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0EB827AE203A58F500579A3E /* CollectionViewCollectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EB827AD203A58F500579A3E /* CollectionViewCollectionProvider.swift */; };
 		A31524C31FF4329B0043CEB3 /* YetAnotherAnimationLibrary.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B15029111EA66FC400F89915 /* YetAnotherAnimationLibrary.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A3299F342064ED690075A137 /* VisibleFrameInsetLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3299F332064ED690075A137 /* VisibleFrameInsetLayout.swift */; };
+		A363C56520C7EA44009A885F /* ViewProviderComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56420C7EA44009A885F /* ViewProviderComposer.swift */; };
+		A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */; };
 		A372A3691C79567A0023C797 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A372A3681C79567A0023C797 /* MessageCell.swift */; };
 		A3DDEECF1C7D88430053BFAE /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DDEECE1C7D88430053BFAE /* Messages.swift */; };
 		A3FC21C81C6EE5AA008566BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC21C71C6EE5AA008566BB /* AppDelegate.swift */; };
@@ -130,6 +132,8 @@
 		A3299F332064ED690075A137 /* VisibleFrameInsetLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibleFrameInsetLayout.swift; sourceTree = "<group>"; };
 		A351C3451CE4CCD2005E15A7 /* CollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionView.swift; sourceTree = "<group>"; };
 		A351C3461CE4CCD2005E15A7 /* Util.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
+		A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewProvider.swift; sourceTree = "<group>"; };
+		A363C56420C7EA44009A885F /* ViewProviderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewProviderComposer.swift; sourceTree = "<group>"; };
 		A372A3681C79567A0023C797 /* MessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
 		A3DDEECE1C7D88430053BFAE /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A3FC21C41C6EE5AA008566BB /* CollectionKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollectionKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -423,7 +427,9 @@
 			isa = PBXGroup;
 			children = (
 				B1E861EF1F21514E00621BA0 /* CollectionViewProvider.swift */,
+				A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */,
 				B144CE101F437AAB0073CF4E /* ClosureViewProvider.swift */,
+				A363C56420C7EA44009A885F /* ViewProviderComposer.swift */,
 			);
 			path = ViewProvider;
 			sourceTree = "<group>";
@@ -710,12 +716,14 @@
 				B144CE041F437A100073CF4E /* FlowLayout.swift in Sources */,
 				B10A06281F20073C00069E17 /* CollectionPresenter.swift in Sources */,
 				B1688A2D1F25632900C229BD /* SpaceCollectionProvider.swift in Sources */,
+				A363C56520C7EA44009A885F /* ViewProviderComposer.swift in Sources */,
 				B1B7B0611E7DAD2700F2483E /* Util.swift in Sources */,
 				B144CE0A1F437A6B0073CF4E /* BaseCollectionProvider.swift in Sources */,
 				B144CE061F437A1D0073CF4E /* RowLayout.swift in Sources */,
 				B19D64C91F23DCA800D02FDB /* CollectionReuseViewManager.swift in Sources */,
 				B144CE001F4379DA0073CF4E /* ClosureLayout.swift in Sources */,
 				B1E861F11F21515F00621BA0 /* CollectionViewProvider.swift in Sources */,
+				A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */,
 				B144CE0D1F437A960073CF4E /* ArrayDataProvider.swift in Sources */,
 				B14B0E021F2682EA003E5105 /* CollectionSizeProvider.swift in Sources */,
 				B1ED75B51F58C95200CB772A /* FloatLayout.swift in Sources */,

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */; };
 		A363C56A20C955C7009A885F /* LayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56920C955C7009A885F /* LayoutContext.swift */; };
 		A363C56C20CACA8A009A885F /* FlattenedProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56B20CACA89009A885F /* FlattenedProvider.swift */; };
+		A363C56E20CBD55B009A885F /* CollectionHeaderComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56D20CBD55B009A885F /* CollectionHeaderComposer.swift */; };
+		A363C57020CBF6A1009A885F /* HeaderExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56F20CBF6A1009A885F /* HeaderExampleViewController.swift */; };
 		A372A3691C79567A0023C797 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A372A3681C79567A0023C797 /* MessageCell.swift */; };
 		A3DDEECF1C7D88430053BFAE /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DDEECE1C7D88430053BFAE /* Messages.swift */; };
 		A3FC21C81C6EE5AA008566BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC21C71C6EE5AA008566BB /* AppDelegate.swift */; };
@@ -138,6 +140,8 @@
 		A363C56420C7EA44009A885F /* ViewProviderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewProviderComposer.swift; sourceTree = "<group>"; };
 		A363C56920C955C7009A885F /* LayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutContext.swift; sourceTree = "<group>"; };
 		A363C56B20CACA89009A885F /* FlattenedProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlattenedProvider.swift; sourceTree = "<group>"; };
+		A363C56D20CBD55B009A885F /* CollectionHeaderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionHeaderComposer.swift; sourceTree = "<group>"; };
+		A363C56F20CBF6A1009A885F /* HeaderExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HeaderExampleViewController.swift; path = Examples/HeaderExample/HeaderExampleViewController.swift; sourceTree = SOURCE_ROOT; };
 		A372A3681C79567A0023C797 /* MessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
 		A3DDEECE1C7D88430053BFAE /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A3FC21C41C6EE5AA008566BB /* CollectionKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollectionKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -265,6 +269,14 @@
 			path = "ChatExample (Advance)";
 			sourceTree = "<group>";
 		};
+		A363C57120CBF6A8009A885F /* HeaderExample */ = {
+			isa = PBXGroup;
+			children = (
+				A363C56F20CBF6A1009A885F /* HeaderExampleViewController.swift */,
+			);
+			path = HeaderExample;
+			sourceTree = "<group>";
+		};
 		A3DDEED01C7D893D0053BFAE /* Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -337,6 +349,7 @@
 				B145FFA11F5DF54900A4F318 /* ExampleView.swift */,
 				0E32583B1F5DC89900D455F8 /* ArticleExample */,
 				A351C3441CE4C917005E15A7 /* ChatExample (Advance) */,
+				A363C57120CBF6A8009A885F /* HeaderExample */,
 				B136E9A11D04C0D500D02FCA /* GridExample */,
 				A3E7918A1D11025B005D9410 /* HorizontalGalleryExample */,
 				B145FFA71F5DFA0100A4F318 /* PresenterExample */,
@@ -413,6 +426,7 @@
 			children = (
 				B148237A1F1E87F60007A7E2 /* CollectionProvider.swift */,
 				B1E861F81F21520200621BA0 /* CollectionComposer.swift */,
+				A363C56D20CBD55B009A885F /* CollectionHeaderComposer.swift */,
 				B1688A2E1F2563A200C229BD /* AnyCollectionProvider.swift */,
 				A363C56B20CACA89009A885F /* FlattenedProvider.swift */,
 				B144CE091F437A6B0073CF4E /* EmptyCollectionProvider.swift */,
@@ -692,6 +706,7 @@
 				B1688A271F25448900C229BD /* ViewController.swift in Sources */,
 				B145FFA61F5DF60300A4F318 /* CollectionViewController.swift in Sources */,
 				B1A073701F438A3500E28E23 /* EdgeShrinkPresenter.swift in Sources */,
+				A363C57020CBF6A1009A885F /* HeaderExampleViewController.swift in Sources */,
 				B14ABA2D1FE2F59B005D889A /* ReloadAnimationViewController.swift in Sources */,
 				0E3258401F5DC8B400D455F8 /* ArticleExampleViewController.swift in Sources */,
 				B100C3FC1EA55DB500868840 /* Util.swift in Sources */,
@@ -749,6 +764,7 @@
 				B1688A291F2562AC00C229BD /* ViewCollectionProvider.swift in Sources */,
 				B1E861F91F21520200621BA0 /* CollectionComposer.swift in Sources */,
 				B1688A2F1F2563A200C229BD /* AnyCollectionProvider.swift in Sources */,
+				A363C56E20CBD55B009A885F /* CollectionHeaderComposer.swift in Sources */,
 				B144CE021F4379F20073CF4E /* WaterfallLayout.swift in Sources */,
 				B144CE151F437AC10073CF4E /* ZoomPresenter.swift in Sources */,
 				B183C11E1F63218E00CEAAE1 /* LayoutHelper.swift in Sources */,

--- a/CollectionKit.xcodeproj/project.pbxproj
+++ b/CollectionKit.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A363C56520C7EA44009A885F /* ViewProviderComposer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56420C7EA44009A885F /* ViewProviderComposer.swift */; };
 		A363C56620C7EA66009A885F /* AnyCollectionViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */; };
 		A363C56A20C955C7009A885F /* LayoutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56920C955C7009A885F /* LayoutContext.swift */; };
+		A363C56C20CACA8A009A885F /* FlattenedProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A363C56B20CACA89009A885F /* FlattenedProvider.swift */; };
 		A372A3691C79567A0023C797 /* MessageCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A372A3681C79567A0023C797 /* MessageCell.swift */; };
 		A3DDEECF1C7D88430053BFAE /* Messages.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3DDEECE1C7D88430053BFAE /* Messages.swift */; };
 		A3FC21C81C6EE5AA008566BB /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC21C71C6EE5AA008566BB /* AppDelegate.swift */; };
@@ -38,7 +39,7 @@
 		B144CE021F4379F20073CF4E /* WaterfallLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE011F4379F20073CF4E /* WaterfallLayout.swift */; };
 		B144CE041F437A100073CF4E /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE031F437A100073CF4E /* FlowLayout.swift */; };
 		B144CE061F437A1D0073CF4E /* RowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE051F437A1D0073CF4E /* RowLayout.swift */; };
-		B144CE0A1F437A6B0073CF4E /* BaseCollectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE091F437A6B0073CF4E /* BaseCollectionProvider.swift */; };
+		B144CE0A1F437A6B0073CF4E /* EmptyCollectionProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE091F437A6B0073CF4E /* EmptyCollectionProvider.swift */; };
 		B144CE0D1F437A960073CF4E /* ArrayDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE0C1F437A960073CF4E /* ArrayDataProvider.swift */; };
 		B144CE0F1F437A9E0073CF4E /* ClosureDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE0E1F437A9E0073CF4E /* ClosureDataProvider.swift */; };
 		B144CE111F437AAB0073CF4E /* ClosureViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B144CE101F437AAB0073CF4E /* ClosureViewProvider.swift */; };
@@ -136,6 +137,7 @@
 		A363C56220C7EA2E009A885F /* AnyCollectionViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyCollectionViewProvider.swift; sourceTree = "<group>"; };
 		A363C56420C7EA44009A885F /* ViewProviderComposer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewProviderComposer.swift; sourceTree = "<group>"; };
 		A363C56920C955C7009A885F /* LayoutContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutContext.swift; sourceTree = "<group>"; };
+		A363C56B20CACA89009A885F /* FlattenedProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlattenedProvider.swift; sourceTree = "<group>"; };
 		A372A3681C79567A0023C797 /* MessageCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageCell.swift; sourceTree = "<group>"; };
 		A3DDEECE1C7D88430053BFAE /* Messages.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = Messages.swift; sourceTree = "<group>"; tabWidth = 2; };
 		A3FC21C41C6EE5AA008566BB /* CollectionKitExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CollectionKitExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -159,7 +161,7 @@
 		B144CE011F4379F20073CF4E /* WaterfallLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaterfallLayout.swift; sourceTree = "<group>"; };
 		B144CE031F437A100073CF4E /* FlowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowLayout.swift; sourceTree = "<group>"; };
 		B144CE051F437A1D0073CF4E /* RowLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowLayout.swift; sourceTree = "<group>"; };
-		B144CE091F437A6B0073CF4E /* BaseCollectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseCollectionProvider.swift; sourceTree = "<group>"; };
+		B144CE091F437A6B0073CF4E /* EmptyCollectionProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyCollectionProvider.swift; sourceTree = "<group>"; };
 		B144CE0C1F437A960073CF4E /* ArrayDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayDataProvider.swift; sourceTree = "<group>"; };
 		B144CE0E1F437A9E0073CF4E /* ClosureDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureDataProvider.swift; sourceTree = "<group>"; };
 		B144CE101F437AAB0073CF4E /* ClosureViewProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosureViewProvider.swift; sourceTree = "<group>"; };
@@ -412,7 +414,8 @@
 				B148237A1F1E87F60007A7E2 /* CollectionProvider.swift */,
 				B1E861F81F21520200621BA0 /* CollectionComposer.swift */,
 				B1688A2E1F2563A200C229BD /* AnyCollectionProvider.swift */,
-				B144CE091F437A6B0073CF4E /* BaseCollectionProvider.swift */,
+				A363C56B20CACA89009A885F /* FlattenedProvider.swift */,
+				B144CE091F437A6B0073CF4E /* EmptyCollectionProvider.swift */,
 			);
 			path = Provider;
 			sourceTree = "<group>";
@@ -718,10 +721,11 @@
 				B183C1221F634A3200CEAAE1 /* TransposeLayout.swift in Sources */,
 				B144CE041F437A100073CF4E /* FlowLayout.swift in Sources */,
 				B10A06281F20073C00069E17 /* CollectionPresenter.swift in Sources */,
+				A363C56C20CACA8A009A885F /* FlattenedProvider.swift in Sources */,
 				B1688A2D1F25632900C229BD /* SpaceCollectionProvider.swift in Sources */,
 				A363C56520C7EA44009A885F /* ViewProviderComposer.swift in Sources */,
 				B1B7B0611E7DAD2700F2483E /* Util.swift in Sources */,
-				B144CE0A1F437A6B0073CF4E /* BaseCollectionProvider.swift in Sources */,
+				B144CE0A1F437A6B0073CF4E /* EmptyCollectionProvider.swift in Sources */,
 				B144CE061F437A1D0073CF4E /* RowLayout.swift in Sources */,
 				B19D64C91F23DCA800D02FDB /* CollectionReuseViewManager.swift in Sources */,
 				B144CE001F4379DA0073CF4E /* ClosureLayout.swift in Sources */,

--- a/CollectionKitTests/CollectionViewSpec.swift
+++ b/CollectionKitTests/CollectionViewSpec.swift
@@ -51,7 +51,7 @@ class CollectionViewSpec: QuickSpec {
         expect((collectionView.subviews[0] as! UILabel).text) == "1"
         expect((collectionView.subviews[0] as! UILabel).textAlignment) == NSTextAlignment.center
 
-        expect(provider.layout).to(beAKindOf(FlowLayout<Int>.self))
+        expect(provider.layout).to(beAKindOf(FlowLayout.self))
         expect(collectionView.subviews[0].frame) == CGRect(x: 0, y: 0, width: 50, height: 50)
         expect(collectionView.subviews[1].frame) == CGRect(x: 50, y: 0, width: 50, height: 50)
         expect(collectionView.subviews[2].frame) == CGRect(x: 100, y: 0, width: 50, height: 50)

--- a/CollectionKitTests/FlowLayoutSpec.swift
+++ b/CollectionKitTests/FlowLayoutSpec.swift
@@ -15,7 +15,7 @@ class FlowLayoutSpec: QuickSpec {
   override func spec() {
     describe("FlowLayout") {
       it("should not crash when parent size is zero") {
-        let layout = FlowLayout<CGSize>()
+        let layout = FlowLayout()
         layout.mockLayout(parentSize: (0, 0))
         expect(layout.frames.count).to(equal(0))
         layout.mockLayout(parentSize: (0, 0), (200, 50))
@@ -23,31 +23,31 @@ class FlowLayoutSpec: QuickSpec {
       }
 
       it("should wrap child") {
-        let layout = FlowLayout<CGSize>()
+        let layout = FlowLayout()
         layout.mockLayout(parentSize: (100, 100), (50, 50), (50, 50), (50, 50))
         expect(layout.frames).to(equal(frames((0, 0, 50, 50), (50, 0, 50, 50), (0, 50, 50, 50))))
       }
 
       it("should work with linespacing") {
-        let layout = FlowLayout<CGSize>(lineSpacing: 10)
+        let layout = FlowLayout(lineSpacing: 10)
         layout.mockLayout(parentSize: (100, 300), (100, 100), (100, 100), (100, 100))
         expect(layout.frames).to(equal(frames((0, 0, 100, 100), (0, 110, 100, 100), (0, 220, 100, 100))))
       }
 
       it("should work with interitemspacing") {
-        let layout = FlowLayout<CGSize>(interitemSpacing: 10)
+        let layout = FlowLayout(interitemSpacing: 10)
         layout.mockLayout(parentSize: (130, 100), (50, 50), (50, 50), (50, 50))
         expect(layout.frames).to(equal(frames((0, 0, 50, 50), (60, 0, 50, 50), (0, 50, 50, 50))))
       }
 
       it("should work with interitemspacing and linespacing") {
-        let layout = FlowLayout<CGSize>(lineSpacing: 10, interitemSpacing: 10)
+        let layout = FlowLayout(lineSpacing: 10, interitemSpacing: 10)
         layout.mockLayout(parentSize: (130, 130), (50, 50), (50, 50), (50, 50))
         expect(layout.frames).to(equal(frames((0, 0, 50, 50), (60, 0, 50, 50), (0, 60, 50, 50))))
       }
 
       it("should not display cells outside of the visible area") {
-        let layout = FlowLayout<CGSize>().transposed()
+        let layout = FlowLayout().transposed()
         layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
         let visible = layout.visibleIndexes(visibleFrame: CGRect(x: 50, y: 0, width: 100, height: 50))
         expect(visible).to(equal([1, 2]))

--- a/CollectionKitTests/RowLayoutSpec.swift
+++ b/CollectionKitTests/RowLayoutSpec.swift
@@ -15,7 +15,7 @@ class RowLayoutSpec: QuickSpec {
   override func spec() {
     describe("RowLayout") {
       it("should not crash when parent size is zero") {
-        let layout = RowLayout<CGSize>()
+        let layout = RowLayout()
         layout.mockLayout(parentSize: (0, 0))
         expect(layout.frames.count).to(equal(0))
         layout.mockLayout(parentSize: (0, 0), (200, 50))
@@ -23,19 +23,19 @@ class RowLayoutSpec: QuickSpec {
       }
 
       it("should work without flex value") {
-        let layout = RowLayout<CGSize>()
+        let layout = RowLayout()
         layout.mockLayout((200, 50), (200, 50), (200, 50))
         expect(layout.frames).to(equal(frames((0,0,200,50), (200,0,200,50), (400,0,200,50))))
       }
 
       it("should expand flexed item when there is space") {
-        let layout = RowLayout<CGSize>("1")
+        let layout = RowLayout("1")
         layout.mockLayout(parentSize: (700, 50), (200, 50), (200, 50), (200, 50))
         expect(layout.frames).to(equal(frames((0,0,200,50), (200,0, 300, 50), (500,0,200,50))))
       }
 
       it("should not expand flex item where there is not enough space") {
-        let layout = RowLayout<CGSize>("1", "2")
+        let layout = RowLayout("1", "2")
         layout.mockLayout(parentSize: (250, 300), (250, 200), (50, 200), (50, 200))
         expect(layout.frames).to(equal(frames((0,0,250,200), (250,0,50,200), (300,0,50,200))))
       }

--- a/CollectionKitTests/TestUils.swift
+++ b/CollectionKitTests/TestUils.swift
@@ -10,16 +10,32 @@ import UIKit
 import CollectionKit
 import UIKit.UIGestureRecognizerSubclass
 
-extension CollectionLayout where Data == CGSize {
+extension CollectionLayout {
 
-  func mockLayout(parentSize: (CGFloat, CGFloat) = (300, 300), _ childSizes: (CGFloat, CGFloat)...) {
-    layout(collectionSize: CGSize(width: parentSize.0, height: parentSize.1),
-           dataProvider: ArrayDataProvider(data: sizes(childSizes)),
-           sizeProvider: { (index, data, collectionSize) -> CGSize in
-              return data
-    })
+  struct MockLayoutContext: LayoutContext {
+    var parentSize: (CGFloat, CGFloat)
+    var childSizes: [(CGFloat, CGFloat)]
+    var collectionSize: CGSize {
+      return CGSize(width: parentSize.0, height: parentSize.1)
+    }
+    var numberOfItems: Int {
+      return childSizes.count
+    }
+    func data(at: Int) -> Any {
+      return childSizes[at]
+    }
+    func identifier(at: Int) -> String {
+      return "\(at)"
+    }
+    func size(at: Int, collectionSize: CGSize) -> CGSize {
+      let size = childSizes[at]
+      return CGSize(width: size.0, height: size.1)
+    }
   }
 
+  func mockLayout(parentSize: (CGFloat, CGFloat) = (300, 300), _ childSizes: (CGFloat, CGFloat)...) {
+    layout(context: MockLayoutContext(parentSize: parentSize, childSizes: childSizes))
+  }
 }
 
 class SimpleTestProvider<Data>: CollectionProvider<Data, UILabel> {

--- a/Examples/ChatExample (Advance)/MessageCell.swift
+++ b/Examples/ChatExample (Advance)/MessageCell.swift
@@ -9,30 +9,66 @@
 import UIKit
 import CollectionKit
 
-class MessageCell: DynamicView {
+class TextMessageCell: MessageCell {
   var textLabel = UILabel()
-  var imageView: UIImageView?
 
-  var message: Message! {
+  override var message: Message! {
     didSet {
       textLabel.text = message.content
       textLabel.textColor = message.textColor
       textLabel.font = UIFont.systemFont(ofSize: message.fontSize)
+    }
+  }
 
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    textLabel.frame = frame
+    textLabel.numberOfLines = 0
+    addSubview(textLabel)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    textLabel.frame = bounds.insetBy(dx: message.cellPadding, dy: message.cellPadding)
+  }
+}
+
+class ImageMessageCell: MessageCell {
+  var imageView = UIImageView()
+
+  override var message: Message! {
+    didSet {
+      imageView.image = UIImage(named: message.content)
+    }
+  }
+
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    imageView.frame = bounds
+    imageView.contentMode = .scaleAspectFill
+    clipsToBounds = true
+    addSubview(imageView)
+  }
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    imageView.frame = bounds
+  }
+}
+
+class MessageCell: DynamicView {
+
+  var message: Message! {
+    didSet {
       layer.cornerRadius = message.roundedCornder ? 10 : 0
-
-      if message.type == .image {
-        imageView = imageView ?? UIImageView()
-        imageView?.image = UIImage(named: message.content)
-        imageView?.frame = bounds
-        imageView?.contentMode = .scaleAspectFill
-        imageView?.clipsToBounds = true
-        imageView?.layer.cornerRadius = layer.cornerRadius
-        addSubview(imageView!)
-      } else {
-        imageView?.removeFromSuperview()
-        imageView = nil
-      }
 
       if message.showShadow {
         layer.shadowOffset = CGSize(width: 0, height: 5)
@@ -51,9 +87,6 @@ class MessageCell: DynamicView {
 
   override init(frame: CGRect) {
     super.init(frame: frame)
-    addSubview(textLabel)
-    textLabel.frame = frame
-    textLabel.numberOfLines = 0
     layer.shouldRasterize = true
     layer.rasterizationScale = UIScreen.main.scale
     isOpaque = true
@@ -68,8 +101,6 @@ class MessageCell: DynamicView {
     if message?.showShadow ?? false {
       layer.shadowPath = UIBezierPath(roundedRect: bounds, cornerRadius: layer.cornerRadius).cgPath
     }
-    textLabel.frame = bounds.insetBy(dx: message.cellPadding, dy: message.cellPadding)
-    imageView?.frame = bounds
   }
 
   static func sizeForText(_ text: String, fontSize: CGFloat, maxWidth: CGFloat, padding: CGFloat) -> CGSize {

--- a/Examples/ChatExample (Advance)/MessagesViewController.swift
+++ b/Examples/ChatExample (Advance)/MessagesViewController.swift
@@ -17,17 +17,15 @@ class MessageDataProvider: ArrayDataProvider<Message> {
   }
 }
 
-class MessageLayout: SimpleLayout<Message> {
-  override func simpleLayout(collectionSize: CGSize,
-                       dataProvider: CollectionDataProvider<Message>,
-                       sizeProvider: @escaping CollectionSizeProvider<Message>) -> [CGRect] {
+class MessageLayout: SimpleLayout {
+  override func simpleLayout(context: LayoutContext) -> [CGRect] {
     var frames: [CGRect] = []
     var lastMessage: Message?
     var lastFrame: CGRect?
-    let maxWidth: CGFloat = collectionSize.width
+    let maxWidth: CGFloat = context.collectionSize.width
     
-    for i in 0..<dataProvider.numberOfItems {
-      let message = dataProvider.data(at: i)
+    for i in 0..<context.numberOfItems {
+      let message = context.data(at: i) as! Message
       var yHeight: CGFloat = 0
       var xOffset: CGFloat = 0
       var cellFrame = MessageCell.frameForMessage(message, containerWidth: maxWidth)

--- a/Examples/ChatExample (Advance)/MessagesViewController.swift
+++ b/Examples/ChatExample (Advance)/MessagesViewController.swift
@@ -124,14 +124,25 @@ class MessagesViewController: CollectionViewController {
     collectionView.delegate = self
     collectionView.contentInset = UIEdgeInsetsMake(30, 10, 54, 10)
     collectionView.scrollIndicatorInsets = UIEdgeInsetsMake(30, 0, 54, 0)
-    
+
+    let textMessageViewProvider = ClosureViewProvider(viewUpdater: { (view: TextMessageCell, data: Message, at: Int) in
+      view.message = data
+    })
+    let imageMessageViewProvider = ClosureViewProvider(viewUpdater: { (view: ImageMessageCell, data: Message, at: Int) in
+      view.message = data
+    })
     presenter.sourceView = newMessageButton
     presenter.dataProvider = dataProvider
     let provider = CollectionProvider(
       dataProvider: dataProvider,
-      viewUpdater: { (view: MessageCell, data: Message, at: Int) in
-        view.message = data
-      }
+      viewProvider: ViewProviderComposer(viewProviderSelector: { data in
+        switch data.type {
+        case .image:
+          return imageMessageViewProvider
+        default:
+          return textMessageViewProvider
+        }
+      })
     )
     let visibleFrameInsets = UIEdgeInsets(top: -200, left: 0, bottom: -200, right: 0)
     provider.layout = MessageLayout().insetVisibleFrame(by: visibleFrameInsets)

--- a/Examples/ComposeExample/ViewController.swift
+++ b/Examples/ComposeExample/ViewController.swift
@@ -24,6 +24,7 @@ class ViewController: CollectionViewController {
     ("Articles", ArticleExampleViewController.self),
     ("Reload", ReloadDataViewController.self),
     ("Reload Animation", ReloadAnimationViewController.self),
+    ("Header", HeaderExampleViewController.self),
     ("Chat", MessagesViewController.self),
     ("Presenters", PresenterExampleViewController.self)
   ]

--- a/Examples/ComposeExample/ViewController.swift
+++ b/Examples/ComposeExample/ViewController.swift
@@ -12,7 +12,7 @@ import CollectionKit
 let bodyInset = UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16)
 let headerInset = UIEdgeInsets(top: 20, left: 16, bottom: 0, right: 16)
 
-func space(_ height: CGFloat) -> AnyCollectionProvider {
+func space(_ height: CGFloat) -> SpaceCollectionProvider {
   return SpaceCollectionProvider(sizeStrategy: (.fill, .absolute(height)))
 }
 

--- a/Examples/GridExample/GridViewController.swift
+++ b/Examples/GridExample/GridViewController.swift
@@ -33,11 +33,9 @@ class GridViewController: CollectionViewController {
     collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
     let provider = CollectionProvider(
       dataProvider: dataProvider,
-      viewUpdater: { (view: UILabel, data: Int, index: Int) in
+      viewUpdater: { (view: SquareView, data: Int, index: Int) in
         view.backgroundColor = UIColor(hue: CGFloat(index) / CGFloat(kGridSize.width * kGridSize.height),
                                        saturation: 0.68, brightness: 0.98, alpha: 1)
-        view.textColor = .white
-        view.textAlignment = .center
         view.text = "\(data)"
       }
     )

--- a/Examples/GridExample/GridViewController.swift
+++ b/Examples/GridExample/GridViewController.swift
@@ -22,7 +22,7 @@ class GridViewController: CollectionViewController {
     })
     let visibleFrameInsets = UIEdgeInsets(top: -150, left: -150, bottom: -150, right: -150)
     let layout = Closurelayout(
-      frameProvider: { (i: Int, data: Int,  _) in
+      frameProvider: { (i: Int, _) in
         CGRect(x: CGFloat(i % kGridSize.width) * (kGridCellSize.width + kGridCellPadding),
                y: CGFloat(i / kGridSize.width) * (kGridCellSize.height + kGridCellPadding),
                width: kGridCellSize.width,

--- a/Examples/HeaderExample/HeaderExampleViewController.swift
+++ b/Examples/HeaderExample/HeaderExampleViewController.swift
@@ -36,17 +36,15 @@ class HeaderExampleViewController: CollectionViewController {
     let sections: [AnyCollectionProvider] = (1...10).map { _ in
       return CollectionProvider(
         data: Array(1...9),
-        viewUpdater: { (view: UILabel, data: Int, index: Int) in
+        viewUpdater: { (view: SquareView, data: Int, index: Int) in
           view.backgroundColor = UIColor(hue: CGFloat(index) / 10,
                                          saturation: 0.68, brightness: 0.98, alpha: 1)
-          view.textColor = .white
-          view.textAlignment = .center
           view.text = "\(data)"
         },
-        layout: FlowLayout(spacing: 10, justifyContent: .center, alignItems: .center)
+        layout: FlowLayout(spacing: 10, justifyContent: .spaceAround, alignItems: .center)
           .inset(by: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)),
         sizeProvider: { (index, data, maxSize) -> CGSize in
-          return CGSize(width: 100, height: 100)
+          return CGSize(width: 80, height: 80)
         }
       )
     }

--- a/Examples/HeaderExample/HeaderExampleViewController.swift
+++ b/Examples/HeaderExample/HeaderExampleViewController.swift
@@ -11,8 +11,27 @@ import CollectionKit
 
 class HeaderExampleViewController: CollectionViewController {
 
+  let toggleButton: UIButton = {
+    let button = UIButton()
+    button.setTitle("Toggle Sticky Header", for: .normal)
+    button.titleLabel?.font = .boldSystemFont(ofSize: 20)
+    button.backgroundColor = UIColor(hue: 0.6, saturation: 0.68, brightness: 0.98, alpha: 1)
+    button.layer.shadowColor = UIColor.black.cgColor
+    button.layer.shadowOffset = CGSize(width: 0, height: -12)
+    button.layer.shadowRadius = 10
+    button.layer.shadowOpacity = 0.1
+    return button
+  }()
+
+  var headerComposer: CollectionHeaderComposer<UILabel>!
+
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    toggleButton.addTarget(self, action: #selector(toggleSticky), for: .touchUpInside)
+    view.addSubview(toggleButton)
+
+    collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 44, right: 0)
 
     let sections: [AnyCollectionProvider] = (1...10).map { _ in
       return CollectionProvider(
@@ -46,7 +65,16 @@ class HeaderExampleViewController: CollectionViewController {
       sections: sections
     )
 
+    self.headerComposer = provider
     self.provider = provider
   }
 
+  @objc func toggleSticky() {
+    headerComposer.isSticky = !headerComposer.isSticky
+  }
+
+  override func viewDidLayoutSubviews() {
+    super.viewDidLayoutSubviews()
+    toggleButton.frame = CGRect(x: 0, y: view.bounds.height - 44, width: view.bounds.width, height: 44)
+  }
 }

--- a/Examples/HeaderExample/HeaderExampleViewController.swift
+++ b/Examples/HeaderExample/HeaderExampleViewController.swift
@@ -1,0 +1,52 @@
+//
+//  HeaderExampleViewController.swift
+//  CollectionKitExample
+//
+//  Created by Luke Zhao on 2018-06-09.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+import CollectionKit
+
+class HeaderExampleViewController: CollectionViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let sections: [AnyCollectionProvider] = (1...10).map { _ in
+      return CollectionProvider(
+        data: Array(1...9),
+        viewUpdater: { (view: UILabel, data: Int, index: Int) in
+          view.backgroundColor = UIColor(hue: CGFloat(index) / 10,
+                                         saturation: 0.68, brightness: 0.98, alpha: 1)
+          view.textColor = .white
+          view.textAlignment = .center
+          view.text = "\(data)"
+        },
+        layout: FlowLayout(spacing: 10, justifyContent: .center, alignItems: .center)
+          .inset(by: UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)),
+        sizeProvider: { (index, data, maxSize) -> CGSize in
+          return CGSize(width: 100, height: 100)
+        }
+      )
+    }
+
+    let provider = CollectionHeaderComposer(
+      headerViewProvider: ClosureViewProvider(
+        viewUpdater: { (view: UILabel, data: (index: Int, section: AnyCollectionProvider), index) in
+          view.backgroundColor = UIColor.darkGray
+          view.textColor = .white
+          view.textAlignment = .center
+          view.text = "Header \(index)"
+      }),
+      headerSizeProvider: { (index, data, maxSize) -> CGSize in
+        return CGSize(width: maxSize.width, height: 40)
+      },
+      sections: sections
+    )
+
+    self.provider = provider
+  }
+
+}

--- a/Examples/HorizontalGalleryExample/HorizontalGalleryViewController.swift
+++ b/Examples/HorizontalGalleryExample/HorizontalGalleryViewController.swift
@@ -37,7 +37,7 @@ class HorizontalGalleryViewController: CollectionViewController {
     })
 
     let visibleFrameInsets = UIEdgeInsets(top: 0, left: -100, bottom: 0, right: -100)
-    provider.layout = WaterfallLayout<UIImage>(columns: 2).transposed().insetVisibleFrame(by: visibleFrameInsets)
+    provider.layout = WaterfallLayout(columns: 2).transposed().insetVisibleFrame(by: visibleFrameInsets)
     provider.sizeProvider = imageSizeProvider
     provider.presenter = WobblePresenter()
     self.provider = provider

--- a/Examples/ReloadAnimationExample/ReloadAnimationViewController.swift
+++ b/Examples/ReloadAnimationExample/ReloadAnimationViewController.swift
@@ -95,10 +95,10 @@ class ReloadAnimationViewController: CollectionViewController {
 
   var currentDataIndex = 0
   var data: [[Int]] = [
-    [],
     [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18],
     [2,3,5,8,10],
     [8,9,10,11,12,13,14,15,16],
+    [],
   ]
 
   override func viewDidLoad() {
@@ -106,24 +106,21 @@ class ReloadAnimationViewController: CollectionViewController {
     reloadButton.addTarget(self, action: #selector(reload), for: .touchUpInside)
     view.addSubview(reloadButton)
 
-    collectionView.contentInset = UIEdgeInsetsMake(20, 10, 20, 10)
+    collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 54, right: 10)
     let layout = FlowLayout(lineSpacing: 15,
                             interitemSpacing: 15,
                             justifyContent: .spaceAround,
                             alignItems: .center,
                             alignContent: .center)
     let presenter = AnimatedReloadPresenter(entryTransform: AnimatedReloadPresenter.fancyEntryTransform)
+    dataProvider.data = data[0]
     let provider = CollectionProvider(
       dataProvider: dataProvider,
-      viewUpdater: { (view: UILabel, data: Int, index: Int) in
+      viewUpdater: { (view: SquareView, data: Int, index: Int) in
         view.backgroundColor = UIColor(hue: CGFloat(data) / 30,
                                        saturation: 0.68,
                                        brightness: 0.98,
                                        alpha: 1)
-        view.textColor = .white
-        view.textAlignment = .center
-        view.layer.cornerRadius = 4
-        view.layer.masksToBounds = true
         view.text = "\(data)"
       }
     )
@@ -140,10 +137,8 @@ class ReloadAnimationViewController: CollectionViewController {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    let viewWidth = view.bounds.width
-    let viewHeight = view.bounds.height
-    reloadButton.frame = CGRect(x: 0, y: viewHeight - 44, width: viewWidth, height: 44)
-    collectionView.frame = CGRect(x: 0, y: 0, width: viewWidth, height: viewHeight - 44)
+    reloadButton.frame = CGRect(x: 0, y: view.bounds.height - 44,
+                                width: view.bounds.width, height: 44)
   }
 
   @objc func reload() {

--- a/Examples/ReloadAnimationExample/ReloadAnimationViewController.swift
+++ b/Examples/ReloadAnimationExample/ReloadAnimationViewController.swift
@@ -107,11 +107,11 @@ class ReloadAnimationViewController: CollectionViewController {
     view.addSubview(reloadButton)
 
     collectionView.contentInset = UIEdgeInsetsMake(20, 10, 20, 10)
-    let layout = FlowLayout<Int>(lineSpacing: 15,
-                                 interitemSpacing: 15,
-                                 justifyContent: .spaceAround,
-                                 alignItems: .center,
-                                 alignContent: .center)
+    let layout = FlowLayout(lineSpacing: 15,
+                            interitemSpacing: 15,
+                            justifyContent: .spaceAround,
+                            alignItems: .center,
+                            alignContent: .center)
     let presenter = AnimatedReloadPresenter(entryTransform: AnimatedReloadPresenter.fancyEntryTransform)
     let provider = CollectionProvider(
       dataProvider: dataProvider,

--- a/Examples/ReloadDataExample/ReloadDataViewController.swift
+++ b/Examples/ReloadDataExample/ReloadDataViewController.swift
@@ -46,15 +46,11 @@ class ReloadDataViewController: CollectionViewController {
     presenter.updateAnimation = .normal
     let provider = CollectionProvider(
       dataProvider: dataProvider,
-      viewUpdater: { (view: UILabel, data: Int, index: Int) in
+      viewUpdater: { (view: SquareView, data: Int, index: Int) in
         view.backgroundColor = UIColor(hue: CGFloat(data) / 30,
                                        saturation: 0.68,
                                        brightness: 0.98,
                                        alpha: 1)
-        view.textColor = .white
-        view.textAlignment = .center
-        view.layer.cornerRadius = 4
-        view.layer.masksToBounds = true
         view.text = "\(data)"
       }
     )

--- a/Examples/ReloadDataExample/ReloadDataViewController.swift
+++ b/Examples/ReloadDataExample/ReloadDataViewController.swift
@@ -35,11 +35,11 @@ class ReloadDataViewController: CollectionViewController {
     view.addSubview(addButton)
 
     collectionView.contentInset = UIEdgeInsetsMake(10, 10, 10, 10)
-    let layout = FlowLayout<Int>(lineSpacing: 15,
-                                 interitemSpacing: 15,
-                                 justifyContent: .spaceAround,
-                                 alignItems: .center,
-                                 alignContent: .center)
+    let layout = FlowLayout(lineSpacing: 15,
+                            interitemSpacing: 15,
+                            justifyContent: .spaceAround,
+                            alignItems: .center,
+                            alignContent: .center)
     let presenter = CollectionPresenter()
     presenter.insertAnimation = .scale
     presenter.deleteAnimation = .scale

--- a/Examples/ReloadDataExample/ReloadDataViewController.swift
+++ b/Examples/ReloadDataExample/ReloadDataViewController.swift
@@ -34,7 +34,7 @@ class ReloadDataViewController: CollectionViewController {
     addButton.addTarget(self, action: #selector(add), for: .touchUpInside)
     view.addSubview(addButton)
 
-    collectionView.contentInset = UIEdgeInsetsMake(10, 10, 10, 10)
+    collectionView.contentInset = UIEdgeInsets(top: 10, left: 10, bottom: 54, right: 10)
     let layout = FlowLayout(lineSpacing: 15,
                             interitemSpacing: 15,
                             justifyContent: .spaceAround,
@@ -71,10 +71,8 @@ class ReloadDataViewController: CollectionViewController {
 
   override func viewDidLayoutSubviews() {
     super.viewDidLayoutSubviews()
-    let viewWidth = view.bounds.width
-    let viewHeight = view.bounds.height
-    addButton.frame = CGRect(x: 0, y: viewHeight - 44, width: viewWidth, height: 44)
-    collectionView.frame = CGRect(x: 0, y: 0, width: viewWidth, height: viewHeight - 44)
+    addButton.frame = CGRect(x: 0, y: view.bounds.height - 44,
+                             width: view.bounds.width, height: 44)
   }
 
   @objc func add() {

--- a/Examples/Supporting Files/SquareView.swift
+++ b/Examples/Supporting Files/SquareView.swift
@@ -1,0 +1,38 @@
+//
+//  SquareView.swift
+//  CollectionKitExample
+//
+//  Created by Luke Zhao on 2018-06-09.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+class SquareView: DynamicView {
+
+  let textLabel = UILabel()
+
+  var text: String? {
+    get { return textLabel.text }
+    set { textLabel.text = newValue }
+  }
+
+  public override init(frame: CGRect) {
+    super.init(frame: frame)
+    layer.cornerRadius = 4
+
+    textLabel.textColor = .white
+    textLabel.textAlignment = .center
+    addSubview(textLabel)
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    textLabel.frame = bounds
+  }
+
+}

--- a/Sources/Addon/EmptyStateCollectionProvider.swift
+++ b/Sources/Addon/EmptyStateCollectionProvider.swift
@@ -35,7 +35,7 @@ public class EmptyStateCollectionProvider: CollectionComposer {
       super.willReload()
     } else if content.numberOfItems > 0, sections.first !== content {
       sections = [content]
-      prepareForReload() // no need to call willReload on `content`
+//      prepareForReload() // no need to call willReload on `content`
     } else {
       super.willReload()
     }

--- a/Sources/Addon/EmptyStateCollectionProvider.swift
+++ b/Sources/Addon/EmptyStateCollectionProvider.swift
@@ -35,7 +35,6 @@ public class EmptyStateCollectionProvider: CollectionComposer {
       super.willReload()
     } else if content.numberOfItems > 0, sections.first !== content {
       sections = [content]
-//      prepareForReload() // no need to call willReload on `content`
     } else {
       super.willReload()
     }

--- a/Sources/Addon/SpaceCollectionProvider.swift
+++ b/Sources/Addon/SpaceCollectionProvider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class SpaceCollectionProvider: BaseCollectionProvider {
+open class SpaceCollectionProvider: EmptyCollectionProvider {
   public enum SpaceSizeStrategy {
     case fill
     case absolute(CGFloat)

--- a/Sources/Addon/ViewCollectionProvider.swift
+++ b/Sources/Addon/ViewCollectionProvider.swift
@@ -48,7 +48,7 @@ open class ViewCollectionProvider: CollectionProvider<UIView, UIView> {
   public init(identifier: String? = nil,
               views: [UIView],
               sizeStrategy: (width: ViewSizeStrategy, height: ViewSizeStrategy) = (.fit, .fit),
-              layout: CollectionLayout<UIView>) {
+              layout: CollectionLayout) {
     self.sizeStrategy = sizeStrategy
     super.init(dataProvider: ArrayDataProvider(data: views, identifierMapper: {
                  return "\($1.hash)"

--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -32,7 +32,7 @@ open class CollectionView: UIScrollView {
   public private(set) var visibleCells: [UIView] = []
   public private(set) var visibleIdentifiers: [String] = []
 
-  lazy var flattenedProvider: ViewOnlyCollectionProvider = provider.flattenedProvider()
+  lazy var flattenedProvider: ViewSource = provider.flattenedProvider()
   var currentlyInsertedCells: Set<UIView>?
   var lastLoadBounds: CGRect?
 

--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -9,8 +9,14 @@
 import UIKit
 
 open class CollectionView: UIScrollView {
-  public var provider: AnyCollectionProvider = BaseCollectionProvider() { didSet { setNeedsReload() } }
-  public var presenter: CollectionPresenter = CollectionPresenter() { didSet { setNeedsReload() } }
+
+  public var provider: AnyCollectionProvider = EmptyCollectionProvider() {
+    didSet { setNeedsReload() }
+  }
+
+  public var presenter: CollectionPresenter = CollectionPresenter() {
+    didSet { setNeedsReload() }
+  }
 
   public private(set) var reloadCount = 0
   public private(set) var needsReload = true
@@ -26,7 +32,7 @@ open class CollectionView: UIScrollView {
   public private(set) var visibleCells: [UIView] = []
   public private(set) var visibleIdentifiers: [String] = []
 
-  lazy var flattenedProvider: ViewOnlyCollectionProvider = ComposedSectionData(provider: provider)
+  lazy var flattenedProvider: ViewOnlyCollectionProvider = provider.flattenedProvider()
   var currentlyInsertedCells: Set<UIView>?
   var lastLoadBounds: CGRect?
 
@@ -36,9 +42,9 @@ open class CollectionView: UIScrollView {
     }
   }
 
-  public convenience init(flattenedProvider: AnyCollectionProvider) {
+  public convenience init(provider: AnyCollectionProvider) {
     self.init()
-    self.flattenedProvider = flattenedProvider
+    self.provider = provider
   }
 
   public override init(frame: CGRect) {

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>2.0.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Layout/ClosureLayout.swift
+++ b/Sources/Layout/ClosureLayout.swift
@@ -8,20 +8,18 @@
 
 import UIKit
 
-public class Closurelayout<Data>: SimpleLayout<Data> {
-  public var frameProvider: (Int, Data, CGSize) -> CGRect
+public class Closurelayout: SimpleLayout {
+  public var frameProvider: (Int, CGSize) -> CGRect
 
-  public init(frameProvider: @escaping (Int, Data, CGSize) -> CGRect) {
+  public init(frameProvider: @escaping (Int, CGSize) -> CGRect) {
     self.frameProvider = frameProvider
     super.init()
   }
 
-  public override func simpleLayout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+  public override func simpleLayout(context: LayoutContext) -> [CGRect] {
     var frames: [CGRect] = []
-    for i in 0..<dataProvider.numberOfItems {
-      let frame = frameProvider(i, dataProvider.data(at: i), collectionSize)
+    for i in 0..<context.numberOfItems {
+      let frame = frameProvider(i, context.collectionSize)
       frames.append(frame)
     }
     return frames

--- a/Sources/Layout/CollectionLayout.swift
+++ b/Sources/Layout/CollectionLayout.swift
@@ -8,11 +8,9 @@
 
 import UIKit
 
-open class CollectionLayout<Data> {
+open class CollectionLayout {
 
-  open func layout(collectionSize: CGSize,
-                   dataProvider: CollectionDataProvider<Data>,
-                   sizeProvider: @escaping CollectionSizeProvider<Data>) {
+  open func layout(context: LayoutContext) {
     fatalError("Subclass should provide its own layout")
   }
 
@@ -32,15 +30,15 @@ open class CollectionLayout<Data> {
 }
 
 extension CollectionLayout {
-  public func transposed() -> TransposeLayout<Data> {
+  public func transposed() -> TransposeLayout {
     return TransposeLayout(self)
   }
 
-  public func inset(by insets: UIEdgeInsets) -> InsetLayout<Data> {
+  public func inset(by insets: UIEdgeInsets) -> InsetLayout {
     return InsetLayout(self, insets: insets)
   }
 
-  public func insetVisibleFrame(by insets: UIEdgeInsets) -> VisibleFrameInsetLayout<Data> {
+  public func insetVisibleFrame(by insets: UIEdgeInsets) -> VisibleFrameInsetLayout {
     return VisibleFrameInsetLayout(self, insets: insets)
   }
 }

--- a/Sources/Layout/FloatLayout.swift
+++ b/Sources/Layout/FloatLayout.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public class FloatLayout<Data>: WrapperLayout<Data> {
+public class FloatLayout: WrapperLayout {
   var floatingFrames: [(index: Int, frame: CGRect)] = []
   var isFloated: (Int, CGRect) -> Bool
 
-  public init(rootLayout: CollectionLayout<Data>,
+  public init(rootLayout: CollectionLayout,
               isFloated: @escaping (Int, CGRect) -> Bool = { index, _ in index % 2 == 0 }) {
     self.isFloated = isFloated
     super.init(rootLayout)
@@ -22,11 +22,9 @@ public class FloatLayout<Data>: WrapperLayout<Data> {
     return rootLayout.contentSize
   }
 
-  override public func layout(collectionSize: CGSize,
-                              dataProvider: CollectionDataProvider<Data>,
-                              sizeProvider: @escaping (Int, Data, CGSize) -> CGSize) {
-    rootLayout.layout(collectionSize: collectionSize, dataProvider: dataProvider, sizeProvider: sizeProvider)
-    floatingFrames = (0..<dataProvider.numberOfItems).map {
+  override public func layout(context: LayoutContext) {
+    rootLayout.layout(context: context)
+    floatingFrames = (0..<context.numberOfItems).map {
       (index: $0, frame: rootLayout.frame(at: $0))
     }.filter {
       isFloated($0.0, $0.1)

--- a/Sources/Layout/FlowLayout.swift
+++ b/Sources/Layout/FlowLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class FlowLayout<Data>: VerticalSimpleLayout<Data> {
+public class FlowLayout: VerticalSimpleLayout {
   public var lineSpacing: CGFloat
   public var interitemSpacing: CGFloat
 
@@ -40,16 +40,14 @@ public class FlowLayout<Data>: VerticalSimpleLayout<Data> {
               alignContent: alignContent)
   }
 
-  public override func simpleLayout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+  public override func simpleLayout(context: LayoutContext) -> [CGRect] {
     var frames: [CGRect] = []
 
-    let sizes = (0..<dataProvider.numberOfItems).map { sizeProvider($0, dataProvider.data(at: $0), collectionSize) }
-    let (totalHeight, lineData) = distributeLines(sizes: sizes, maxWidth: collectionSize.width)
+    let sizes = (0..<context.numberOfItems).map { context.size(at: $0, collectionSize: context.collectionSize) }
+    let (totalHeight, lineData) = distributeLines(sizes: sizes, maxWidth: context.collectionSize.width)
 
     var (yOffset, spacing) = LayoutHelper.distribute(justifyContent: alignContent,
-                                                     maxPrimary: collectionSize.height,
+                                                     maxPrimary: context.collectionSize.height,
                                                      totalPrimary: totalHeight,
                                                      minimunSpacing: lineSpacing,
                                                      numberOfItems: lineData.count)
@@ -58,7 +56,7 @@ public class FlowLayout<Data>: VerticalSimpleLayout<Data> {
     for (lineSize, count) in lineData {
       let (xOffset, lineInteritemSpacing) =
         LayoutHelper.distribute(justifyContent: justifyContent,
-                                maxPrimary: collectionSize.width,
+                                maxPrimary: context.collectionSize.width,
                                 totalPrimary: lineSize.width,
                                 minimunSpacing: interitemSpacing,
                                 numberOfItems: count)

--- a/Sources/Layout/InsetLayout.swift
+++ b/Sources/Layout/InsetLayout.swift
@@ -8,16 +8,37 @@
 
 import UIKit
 
-open class InsetLayout<Data>: WrapperLayout<Data> {
+open class InsetLayout: WrapperLayout {
   public var insets: UIEdgeInsets
   public var insetProvider: ((CGSize) -> UIEdgeInsets)?
 
-  public init(_ rootLayout: CollectionLayout<Data>, insets: UIEdgeInsets = .zero) {
+  struct InsetLayoutContext: LayoutContext {
+    var original: LayoutContext
+    var insets: UIEdgeInsets
+
+    var collectionSize: CGSize {
+      return original.collectionSize.insets(by: insets)
+    }
+    var numberOfItems: Int {
+      return original.numberOfItems
+    }
+    func data(at: Int) -> Any {
+      return original.data(at: at)
+    }
+    func identifier(at: Int) -> String {
+      return original.identifier(at: at)
+    }
+    func size(at: Int, collectionSize: CGSize) -> CGSize {
+      return original.size(at: at, collectionSize: collectionSize)
+    }
+  }
+
+  public init(_ rootLayout: CollectionLayout, insets: UIEdgeInsets = .zero) {
     self.insets = insets
     super.init(rootLayout)
   }
 
-  public init(_ rootLayout: CollectionLayout<Data>, insetProvider: @escaping ((CGSize) -> UIEdgeInsets)) {
+  public init(_ rootLayout: CollectionLayout, insetProvider: @escaping ((CGSize) -> UIEdgeInsets)) {
     self.insets = .zero
     self.insetProvider = insetProvider
     super.init(rootLayout)
@@ -27,14 +48,11 @@ open class InsetLayout<Data>: WrapperLayout<Data> {
     return rootLayout.contentSize.insets(by: -insets)
   }
 
-  open override func layout(collectionSize: CGSize,
-                            dataProvider: CollectionDataProvider<Data>,
-                            sizeProvider: @escaping (Int, Data, CGSize) -> CGSize) {
+  open override func layout(context: LayoutContext) {
     if let insetProvider = insetProvider {
-      insets = insetProvider(collectionSize)
+      insets = insetProvider(context.collectionSize)
     }
-    rootLayout.layout(collectionSize: collectionSize.insets(by: insets),
-                      dataProvider: dataProvider, sizeProvider: sizeProvider)
+    rootLayout.layout(context: InsetLayoutContext(original: context, insets: insets))
   }
 
   open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {

--- a/Sources/Layout/LayoutContext.swift
+++ b/Sources/Layout/LayoutContext.swift
@@ -1,0 +1,36 @@
+//
+//  LayoutContext.swift
+//  CollectionKit
+//
+//  Created by Luke Zhao on 2018-06-07.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+public protocol LayoutContext {
+  var collectionSize: CGSize { get }
+  var numberOfItems: Int { get }
+  func data(at: Int) -> Any
+  func identifier(at: Int) -> String
+  func size(at: Int, collectionSize: CGSize) -> CGSize
+}
+
+struct CollectionProviderLayoutContext<Data>: LayoutContext {
+  var collectionSize: CGSize
+  var dataProvider: CollectionDataProvider<Data>
+  var sizeProvider: CollectionSizeProvider<Data>
+
+  var numberOfItems: Int {
+    return dataProvider.numberOfItems
+  }
+  func data(at: Int) -> Any {
+    return dataProvider.data(at: at)
+  }
+  func identifier(at: Int) -> String {
+    return dataProvider.identifier(at: at)
+  }
+  func size(at: Int, collectionSize: CGSize) -> CGSize {
+    return sizeProvider(at, dataProvider.data(at: at), collectionSize)
+  }
+}

--- a/Sources/Layout/LayoutContext.swift
+++ b/Sources/Layout/LayoutContext.swift
@@ -15,22 +15,3 @@ public protocol LayoutContext {
   func identifier(at: Int) -> String
   func size(at: Int, collectionSize: CGSize) -> CGSize
 }
-
-struct CollectionProviderLayoutContext<Data>: LayoutContext {
-  var collectionSize: CGSize
-  var dataProvider: CollectionDataProvider<Data>
-  var sizeProvider: CollectionSizeProvider<Data>
-
-  var numberOfItems: Int {
-    return dataProvider.numberOfItems
-  }
-  func data(at: Int) -> Any {
-    return dataProvider.data(at: at)
-  }
-  func identifier(at: Int) -> String {
-    return dataProvider.identifier(at: at)
-  }
-  func size(at: Int, collectionSize: CGSize) -> CGSize {
-    return sizeProvider(at, dataProvider.data(at: at), collectionSize)
-  }
-}

--- a/Sources/Layout/OverlayLayout.swift
+++ b/Sources/Layout/OverlayLayout.swift
@@ -8,13 +8,11 @@
 
 import UIKit
 
-public class OverlayLayout<Data>: SimpleLayout<Data> {
-  public override func simpleLayout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+public class OverlayLayout: SimpleLayout {
+  public override func simpleLayout(context: LayoutContext) -> [CGRect] {
     var frames: [CGRect] = []
-    for i in 0..<dataProvider.numberOfItems {
-      let size = sizeProvider(i, dataProvider.data(at: i), collectionSize)
+    for i in 0..<context.numberOfItems {
+      let size = context.size(at: i, collectionSize: context.collectionSize)
       frames.append(CGRect(origin: .zero, size: size))
     }
     return frames

--- a/Sources/Layout/RowLayout.swift
+++ b/Sources/Layout/RowLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class RowLayout<Data>: HorizontalSimpleLayout<Data> {
+public class RowLayout: HorizontalSimpleLayout {
   public var spacing: CGFloat
   public var fillIdentifiers: Set<String>
   public var alignItems: AlignItem
@@ -36,23 +36,19 @@ public class RowLayout<Data>: HorizontalSimpleLayout<Data> {
               justifyContent: justifyContent, alignItems: alignItems)
   }
 
-  public override func simpleLayout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+  public override func simpleLayout(context: LayoutContext) -> [CGRect] {
 
-    let (sizes, totalWidth) = getCellSizes(collectionSize: collectionSize,
-                                           dataProvider: dataProvider,
-                                           sizeProvider: sizeProvider)
+    let (sizes, totalWidth) = getCellSizes(context: context)
 
     let (offset, distributedSpacing) = LayoutHelper.distribute(justifyContent: justifyContent,
-                                                               maxPrimary: collectionSize.width,
+                                                               maxPrimary: context.collectionSize.width,
                                                                totalPrimary: totalWidth,
                                                                minimunSpacing: spacing,
-                                                               numberOfItems: dataProvider.numberOfItems)
+                                                               numberOfItems: context.numberOfItems)
 
     let frames = LayoutHelper.alignItem(alignItems: alignItems,
                                         startingPrimaryOffset: offset, spacing: distributedSpacing,
-                                        sizes: sizes, secondaryRange: 0...max(0, collectionSize.height))
+                                        sizes: sizes, secondaryRange: 0...max(0, context.collectionSize.height))
 
     return frames
   }
@@ -60,29 +56,27 @@ public class RowLayout<Data>: HorizontalSimpleLayout<Data> {
 
 extension RowLayout {
 
-  func getCellSizes(collectionSize: CGSize,
-                    dataProvider: CollectionDataProvider<Data>,
-                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> (sizes: [CGSize], totalWidth: CGFloat) {
+  func getCellSizes(context: LayoutContext) -> (sizes: [CGSize], totalWidth: CGFloat) {
     var sizes: [CGSize] = []
-    let spacings = spacing * CGFloat(dataProvider.numberOfItems - 1)
+    let spacings = spacing * CGFloat(context.numberOfItems - 1)
     var freezedWidth = spacings
     var fillIndexes: [Int] = []
 
-    for i in 0..<dataProvider.numberOfItems {
-      if fillIdentifiers.contains(dataProvider.identifier(at: i)) {
+    for i in 0..<context.numberOfItems {
+      if fillIdentifiers.contains(context.identifier(at: i)) {
         fillIndexes.append(i)
         sizes.append(.zero)
       } else {
-        let size = sizeProvider(i, dataProvider.data(at: i), collectionSize)
+        let size = context.size(at: i, collectionSize: context.collectionSize)
         sizes.append(size)
         freezedWidth += size.width
       }
     }
 
-    let leftOverWidthPerItem: CGFloat = max(0, collectionSize.width - freezedWidth) / CGFloat(fillIndexes.count)
+    let leftOverWidthPerItem: CGFloat = max(0, context.collectionSize.width - freezedWidth) / CGFloat(fillIndexes.count)
     for i in fillIndexes {
-      let size = sizeProvider(i, dataProvider.data(at: i), CGSize(width: leftOverWidthPerItem,
-                                                                  height: collectionSize.height))
+      let size = context.size(at: i, collectionSize: CGSize(width: leftOverWidthPerItem,
+                                                            height: context.collectionSize.height))
       let width = alwaysFillEmptySpaces ? max(leftOverWidthPerItem, size.width) : size.width
       sizes[i] = CGSize(width: width, height: size.height)
       freezedWidth += sizes[i].width

--- a/Sources/Layout/SimpleLayout.swift
+++ b/Sources/Layout/SimpleLayout.swift
@@ -8,13 +8,11 @@
 
 import UIKit
 
-open class SimpleLayout<Data>: CollectionLayout<Data> {
+open class SimpleLayout: CollectionLayout {
   var _contentSize: CGSize = .zero
   public private(set) var frames: [CGRect] = []
 
-  open func simpleLayout(collectionSize: CGSize,
-                         dataProvider: CollectionDataProvider<Data>,
-                         sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+  open func simpleLayout(context: LayoutContext) -> [CGRect] {
     fatalError("Subclass should provide its own layout")
   }
 
@@ -22,11 +20,8 @@ open class SimpleLayout<Data>: CollectionLayout<Data> {
 
   }
 
-  public final override func layout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) {
-    frames = simpleLayout(collectionSize: collectionSize,
-                          dataProvider: dataProvider, sizeProvider: sizeProvider)
+  public final override func layout(context: LayoutContext) {
+    frames = simpleLayout(context: context)
     _contentSize = frames.reduce(CGRect.zero) { (old, item) in
       old.union(item)
     }.size
@@ -52,7 +47,7 @@ open class SimpleLayout<Data>: CollectionLayout<Data> {
   }
 }
 
-open class VerticalSimpleLayout<Data>: SimpleLayout<Data> {
+open class VerticalSimpleLayout: SimpleLayout {
   private var maxFrameLength: CGFloat = 0
 
   open override func doneLayout() {
@@ -76,7 +71,7 @@ open class VerticalSimpleLayout<Data>: SimpleLayout<Data> {
   }
 }
 
-open class HorizontalSimpleLayout<Data>: SimpleLayout<Data> {
+open class HorizontalSimpleLayout: SimpleLayout {
   private var maxFrameLength: CGFloat = 0
 
   open override func doneLayout() {

--- a/Sources/Layout/TransposeLayout.swift
+++ b/Sources/Layout/TransposeLayout.swift
@@ -8,19 +8,33 @@
 
 import UIKit
 
-open class TransposeLayout<Data>: WrapperLayout<Data> {
+open class TransposeLayout: WrapperLayout {
+  struct TransposeLayoutContext: LayoutContext {
+    var original: LayoutContext
+
+    var collectionSize: CGSize {
+      return original.collectionSize.transposed
+    }
+    var numberOfItems: Int {
+      return original.numberOfItems
+    }
+    func data(at: Int) -> Any {
+      return original.data(at: at)
+    }
+    func identifier(at: Int) -> String {
+      return original.identifier(at: at)
+    }
+    func size(at: Int, collectionSize: CGSize) -> CGSize {
+      return original.size(at: at, collectionSize: collectionSize.transposed).transposed
+    }
+  }
 
   open override var contentSize: CGSize {
     return rootLayout.contentSize.transposed
   }
 
-  open override func layout(collectionSize: CGSize,
-                            dataProvider: CollectionDataProvider<Data>,
-                            sizeProvider: @escaping (Int, Data, CGSize) -> CGSize) {
-    rootLayout.layout(collectionSize: collectionSize.transposed,
-                      dataProvider: dataProvider) {
-                        return sizeProvider($0, $1, $2.transposed).transposed
-    }
+  open override func layout(context: LayoutContext) {
+    rootLayout.layout(context: TransposeLayoutContext(original: context))
   }
 
   open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {

--- a/Sources/Layout/VisibleFrameInsetLayout.swift
+++ b/Sources/Layout/VisibleFrameInsetLayout.swift
@@ -8,30 +8,26 @@
 
 import UIKit
 
-open class VisibleFrameInsetLayout<Data>: WrapperLayout<Data> {
+open class VisibleFrameInsetLayout: WrapperLayout {
   public var insets: UIEdgeInsets
   public var insetProvider: ((CGSize) -> UIEdgeInsets)?
 
-  public init(_ rootLayout: CollectionLayout<Data>, insets: UIEdgeInsets = .zero) {
+  public init(_ rootLayout: CollectionLayout, insets: UIEdgeInsets = .zero) {
     self.insets = insets
     super.init(rootLayout)
   }
 
-  public init(_ rootLayout: CollectionLayout<Data>, insetProvider: @escaping ((CGSize) -> UIEdgeInsets)) {
+  public init(_ rootLayout: CollectionLayout, insetProvider: @escaping ((CGSize) -> UIEdgeInsets)) {
     self.insets = .zero
     self.insetProvider = insetProvider
     super.init(rootLayout)
   }
 
-  open override func layout(collectionSize: CGSize,
-                            dataProvider: CollectionDataProvider<Data>,
-                            sizeProvider: @escaping (Int, Data, CGSize) -> CGSize) {
+  open override func layout(context: LayoutContext) {
     if let insetProvider = insetProvider {
-      insets = insetProvider(collectionSize)
+      insets = insetProvider(context.collectionSize)
     }
-    super.layout(collectionSize: collectionSize,
-                 dataProvider: dataProvider,
-                 sizeProvider: sizeProvider)
+    super.layout(context: context)
   }
 
   open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {

--- a/Sources/Layout/WaterfallLayout.swift
+++ b/Sources/Layout/WaterfallLayout.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class WaterfallLayout<Data>: VerticalSimpleLayout<Data> {
+public class WaterfallLayout: VerticalSimpleLayout {
   public var columns: Int
   public var spacing: CGFloat
   private var columnWidth: [CGFloat] = [0, 0]
@@ -20,12 +20,10 @@ public class WaterfallLayout<Data>: VerticalSimpleLayout<Data> {
     super.init()
   }
 
-  public override func simpleLayout(collectionSize: CGSize,
-                                    dataProvider: CollectionDataProvider<Data>,
-                                    sizeProvider: @escaping CollectionSizeProvider<Data>) -> [CGRect] {
+  public override func simpleLayout(context: LayoutContext) -> [CGRect] {
     var frames: [CGRect] = []
 
-    let columnWidth = (collectionSize.width - CGFloat(columns - 1) * spacing) / CGFloat(columns)
+    let columnWidth = (context.collectionSize.width - CGFloat(columns - 1) * spacing) / CGFloat(columns)
     var columnHeight = [CGFloat](repeating: 0, count: columns)
 
     func getMinColomn() -> (Int, CGFloat) {
@@ -36,9 +34,9 @@ public class WaterfallLayout<Data>: VerticalSimpleLayout<Data> {
       return minHeight
     }
 
-    for i in 0..<dataProvider.numberOfItems {
-      var cellSize = sizeProvider(i, dataProvider.data(at: i),
-                                  CGSize(width: columnWidth, height: collectionSize.height))
+    for i in 0..<context.numberOfItems {
+      var cellSize = context.size(at: i, collectionSize: CGSize(width: columnWidth,
+                                                                height: context.collectionSize.height))
       cellSize = CGSize(width: columnWidth, height: cellSize.height)
       let (columnIndex, offsetY) = getMinColomn()
       columnHeight[columnIndex] += cellSize.height + spacing

--- a/Sources/Layout/WrapperLayout.swift
+++ b/Sources/Layout/WrapperLayout.swift
@@ -8,10 +8,10 @@
 
 import UIKit
 
-open class WrapperLayout<Data>: CollectionLayout<Data> {
-  var rootLayout: CollectionLayout<Data>
+open class WrapperLayout: CollectionLayout {
+  var rootLayout: CollectionLayout
 
-  public init(_ rootLayout: CollectionLayout<Data>) {
+  public init(_ rootLayout: CollectionLayout) {
     self.rootLayout = rootLayout
   }
 
@@ -19,10 +19,8 @@ open class WrapperLayout<Data>: CollectionLayout<Data> {
     return rootLayout.contentSize
   }
 
-  open override func layout(collectionSize: CGSize,
-                            dataProvider: CollectionDataProvider<Data>,
-                            sizeProvider: @escaping (Int, Data, CGSize) -> CGSize) {
-    rootLayout.layout(collectionSize: collectionSize, dataProvider: dataProvider, sizeProvider: sizeProvider)
+  open override func layout(context: LayoutContext) {
+    rootLayout.layout(context: context)
   }
 
   open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {

--- a/Sources/Provider/AnyCollectionProvider.swift
+++ b/Sources/Provider/AnyCollectionProvider.swift
@@ -26,28 +26,29 @@ public protocol BaseCollectionProvider {
   func willReload()
   func didReload()
 
+  func presenter(at: Int) -> CollectionPresenter?
+
   // determines if a context belongs to current provider
   func hasReloadable(_ reloadable: CollectionReloadable) -> Bool
 
-  func flattenedProvider() -> ViewOnlyCollectionProvider
+  func flattenedProvider() -> ViewSource
 }
 
-public protocol ComposedCollectionProvider: BaseCollectionProvider {
+public protocol SectionSource: BaseCollectionProvider {
   func section(at: Int) -> AnyCollectionProvider?
 }
 
-public protocol ViewOnlyCollectionProvider: BaseCollectionProvider {
+public protocol ViewSource: BaseCollectionProvider {
   func view(at: Int) -> UIView
   func update(view: UIView, at: Int)
 
   func didTap(view: UIView, at: Int)
-  func presenter(at: Int) -> CollectionPresenter?
 }
 
 public typealias AnyCollectionProvider = BaseCollectionProvider & CollectionReloadable
 
 extension BaseCollectionProvider {
-  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+  public func flattenedProvider() -> ViewSource {
     fatalError("""
       AnyCollectionProvider shouldn't be used by itself,
       please use either ComposedCollectionProvider or ViewOnlyCollectionProvider
@@ -55,14 +56,14 @@ extension BaseCollectionProvider {
   }
 }
 
-extension ComposedCollectionProvider {
-  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+extension SectionSource {
+  public func flattenedProvider() -> ViewSource {
     return FlattenedProvider(provider: self)
   }
 }
 
-extension ViewOnlyCollectionProvider {
-  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+extension ViewSource {
+  public func flattenedProvider() -> ViewSource {
     return self
   }
 }

--- a/Sources/Provider/AnyCollectionProvider.swift
+++ b/Sources/Provider/AnyCollectionProvider.swift
@@ -8,7 +8,12 @@
 
 import UIKit
 
-public protocol AnyCollectionProvider: CollectionReloadable {
+public protocol AnyCollectionProvider: ViewOnlyCollectionProvider, CollectionReloadable {
+  var hasSection: Bool { get }
+  func section(at: Int) -> AnyCollectionProvider?
+}
+
+public protocol ViewOnlyCollectionProvider {
   var identifier: String? { get }
 
   // data
@@ -35,4 +40,144 @@ public protocol AnyCollectionProvider: CollectionReloadable {
 
   // determines if a context belongs to current provider
   func hasReloadable(_ reloadable: CollectionReloadable) -> Bool
+}
+
+extension AnyCollectionProvider {
+  func flattenedProvider() -> ViewOnlyCollectionProvider {
+    if hasSection {
+      return ComposedSectionData(provider: self)
+    } else {
+      return self
+    }
+  }
+}
+
+struct ComposedSectionData: ViewOnlyCollectionProvider {
+
+  var provider: AnyCollectionProvider
+
+  private var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)]
+
+  init(provider: AnyCollectionProvider) {
+    self.provider = provider
+    var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)] = []
+    childSections.reserveCapacity(provider.numberOfItems)
+    var count = 0
+    for i in 0..<provider.numberOfItems {
+      let sectionData: ViewOnlyCollectionProvider?
+      if let section = provider.section(at: i) {
+        sectionData = section.flattenedProvider()
+      } else {
+        sectionData = nil
+      }
+      childSections.append((beginIndex: count, sectionData: sectionData))
+      count += sectionData?.numberOfItems ?? 1
+    }
+    self.childSections = childSections
+  }
+
+  func indexPath(_ index: Int) -> (Int, Int) {
+    let sectionIndex = childSections.binarySearch { $0.beginIndex <= index } - 1
+    return (sectionIndex, index - childSections[sectionIndex].beginIndex)
+  }
+
+  func apply<T>(_ index: Int, with: (ViewOnlyCollectionProvider, Int) -> T) -> T {
+    let (sectionIndex, item) = indexPath(index)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      return with(sectionData, item)
+    } else {
+      return with(provider, sectionIndex)
+    }
+  }
+
+  var identifier: String? {
+    return provider.identifier
+  }
+
+  var numberOfItems: Int {
+    return (childSections.last?.beginIndex ?? 0) + (childSections.last?.sectionData?.numberOfItems ?? 0)
+  }
+
+  func view(at: Int) -> UIView {
+    return apply(at) {
+      $0.view(at: $1)
+    }
+  }
+
+  func update(view: UIView, at: Int) {
+    return apply(at) {
+      $0.update(view: view, at: $1)
+    }
+  }
+
+  func identifier(at: Int) -> String {
+    let (sectionIndex, item) = indexPath(at)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      return provider.identifier(at: sectionIndex) + sectionData.identifier(at: item)
+    } else {
+      return provider.identifier(at: sectionIndex)
+    }
+  }
+
+  func layout(collectionSize: CGSize) {
+    provider.layout(collectionSize: collectionSize)
+  }
+
+  var contentSize: CGSize {
+    return provider.contentSize
+  }
+
+  func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+    var visible = [Int]()
+    for sectionIndex in provider.visibleIndexes(visibleFrame: visibleFrame) {
+      let beginIndex = childSections[sectionIndex].beginIndex
+      if let sectionData = childSections[sectionIndex].sectionData {
+        let sectionFrame = provider.frame(at: sectionIndex)
+        let intersectFrame = visibleFrame.intersection(sectionFrame)
+        let visibleFrameForCell = CGRect(origin: intersectFrame.origin - sectionFrame.origin, size: intersectFrame.size)
+        let sectionVisible = sectionData.visibleIndexes(visibleFrame: visibleFrameForCell)
+        for item in sectionVisible {
+          visible.append(item + beginIndex)
+        }
+      } else {
+        visible.append(beginIndex)
+      }
+    }
+    return visible
+  }
+
+  func frame(at: Int) -> CGRect {
+    let (sectionIndex, item) = indexPath(at)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      var frame = sectionData.frame(at: item)
+      frame.origin += provider.frame(at: sectionIndex).origin
+      return frame
+    } else {
+      return provider.frame(at: sectionIndex)
+    }
+  }
+
+  func presenter(at: Int) -> CollectionPresenter? {
+    return apply(at) {
+      $0.presenter(at: $1)
+    }
+  }
+
+  func willReload() {
+    provider.willReload()
+  }
+
+  func didReload() {
+    provider.didReload()
+  }
+
+  func didTap(view: UIView, at: Int) {
+    return apply(at) {
+      $0.didTap(view: view, at: $1)
+    }
+  }
+
+  func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
+    return provider.hasReloadable(reloadable)
+  }
 }

--- a/Sources/Provider/AnyCollectionProvider.swift
+++ b/Sources/Provider/AnyCollectionProvider.swift
@@ -8,21 +8,12 @@
 
 import UIKit
 
-public protocol AnyCollectionProvider: ViewOnlyCollectionProvider, CollectionReloadable {
-  var hasSection: Bool { get }
-  func section(at: Int) -> AnyCollectionProvider?
-}
-
-public protocol ViewOnlyCollectionProvider {
+public protocol BaseCollectionProvider {
   var identifier: String? { get }
 
   // data
   var numberOfItems: Int { get }
   func identifier(at: Int) -> String
-
-  // view
-  func view(at: Int) -> UIView
-  func update(view: UIView, at: Int)
 
   // layout
   func layout(collectionSize: CGSize)
@@ -34,150 +25,44 @@ public protocol ViewOnlyCollectionProvider {
   // event
   func willReload()
   func didReload()
-  func didTap(view: UIView, at: Int)
-
-  func presenter(at: Int) -> CollectionPresenter?
 
   // determines if a context belongs to current provider
   func hasReloadable(_ reloadable: CollectionReloadable) -> Bool
+
+  func flattenedProvider() -> ViewOnlyCollectionProvider
 }
 
-extension AnyCollectionProvider {
-  func flattenedProvider() -> ViewOnlyCollectionProvider {
-    if hasSection {
-      return ComposedSectionData(provider: self)
-    } else {
-      return self
-    }
+public protocol ComposedCollectionProvider: BaseCollectionProvider {
+  func section(at: Int) -> AnyCollectionProvider?
+}
+
+public protocol ViewOnlyCollectionProvider: BaseCollectionProvider {
+  func view(at: Int) -> UIView
+  func update(view: UIView, at: Int)
+
+  func didTap(view: UIView, at: Int)
+  func presenter(at: Int) -> CollectionPresenter?
+}
+
+public typealias AnyCollectionProvider = BaseCollectionProvider & CollectionReloadable
+
+extension BaseCollectionProvider {
+  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+    fatalError("""
+      AnyCollectionProvider shouldn't be used by itself,
+      please use either ComposedCollectionProvider or ViewOnlyCollectionProvider
+      """)
   }
 }
 
-struct ComposedSectionData: ViewOnlyCollectionProvider {
-
-  var provider: AnyCollectionProvider
-
-  private var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)]
-
-  init(provider: AnyCollectionProvider) {
-    self.provider = provider
-    var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)] = []
-    childSections.reserveCapacity(provider.numberOfItems)
-    var count = 0
-    for i in 0..<provider.numberOfItems {
-      let sectionData: ViewOnlyCollectionProvider?
-      if let section = provider.section(at: i) {
-        sectionData = section.flattenedProvider()
-      } else {
-        sectionData = nil
-      }
-      childSections.append((beginIndex: count, sectionData: sectionData))
-      count += sectionData?.numberOfItems ?? 1
-    }
-    self.childSections = childSections
+extension ComposedCollectionProvider {
+  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+    return FlattenedProvider(provider: self)
   }
+}
 
-  func indexPath(_ index: Int) -> (Int, Int) {
-    let sectionIndex = childSections.binarySearch { $0.beginIndex <= index } - 1
-    return (sectionIndex, index - childSections[sectionIndex].beginIndex)
-  }
-
-  func apply<T>(_ index: Int, with: (ViewOnlyCollectionProvider, Int) -> T) -> T {
-    let (sectionIndex, item) = indexPath(index)
-    if let sectionData = childSections[sectionIndex].sectionData {
-      return with(sectionData, item)
-    } else {
-      return with(provider, sectionIndex)
-    }
-  }
-
-  var identifier: String? {
-    return provider.identifier
-  }
-
-  var numberOfItems: Int {
-    return (childSections.last?.beginIndex ?? 0) + (childSections.last?.sectionData?.numberOfItems ?? 0)
-  }
-
-  func view(at: Int) -> UIView {
-    return apply(at) {
-      $0.view(at: $1)
-    }
-  }
-
-  func update(view: UIView, at: Int) {
-    return apply(at) {
-      $0.update(view: view, at: $1)
-    }
-  }
-
-  func identifier(at: Int) -> String {
-    let (sectionIndex, item) = indexPath(at)
-    if let sectionData = childSections[sectionIndex].sectionData {
-      return provider.identifier(at: sectionIndex) + sectionData.identifier(at: item)
-    } else {
-      return provider.identifier(at: sectionIndex)
-    }
-  }
-
-  func layout(collectionSize: CGSize) {
-    provider.layout(collectionSize: collectionSize)
-  }
-
-  var contentSize: CGSize {
-    return provider.contentSize
-  }
-
-  func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    var visible = [Int]()
-    for sectionIndex in provider.visibleIndexes(visibleFrame: visibleFrame) {
-      let beginIndex = childSections[sectionIndex].beginIndex
-      if let sectionData = childSections[sectionIndex].sectionData {
-        let sectionFrame = provider.frame(at: sectionIndex)
-        let intersectFrame = visibleFrame.intersection(sectionFrame)
-        let visibleFrameForCell = CGRect(origin: intersectFrame.origin - sectionFrame.origin, size: intersectFrame.size)
-        let sectionVisible = sectionData.visibleIndexes(visibleFrame: visibleFrameForCell)
-        for item in sectionVisible {
-          visible.append(item + beginIndex)
-        }
-      } else {
-        visible.append(beginIndex)
-      }
-    }
-    return visible
-  }
-
-  func frame(at: Int) -> CGRect {
-    let (sectionIndex, item) = indexPath(at)
-    if let sectionData = childSections[sectionIndex].sectionData {
-      var frame = sectionData.frame(at: item)
-      frame.origin += provider.frame(at: sectionIndex).origin
-      return frame
-    } else {
-      return provider.frame(at: sectionIndex)
-    }
-  }
-
-  func presenter(at: Int) -> CollectionPresenter? {
-    return apply(at) {
-      $0.presenter(at: $1)
-    }
-  }
-
-  func willReload() {
-    provider.willReload()
-  }
-
-  func didReload() {
-    provider.didReload()
-  }
-
-  func didTap(view: UIView, at: Int) {
-    return apply(at) {
-      $0.didTap(view: view, at: $1)
-    }
-  }
-
-  func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
-    return provider.hasReloadable(reloadable)
+extension ViewOnlyCollectionProvider {
+  public func flattenedProvider() -> ViewOnlyCollectionProvider {
+    return self
   }
 }

--- a/Sources/Provider/BaseCollectionProvider.swift
+++ b/Sources/Provider/BaseCollectionProvider.swift
@@ -18,6 +18,12 @@ open class BaseCollectionProvider: AnyCollectionProvider {
   open var numberOfItems: Int {
     return 0
   }
+  public var hasSection: Bool {
+    return false
+  }
+  public func section(at: Int) -> AnyCollectionProvider? {
+    return nil
+  }
   open func view(at: Int) -> UIView {
     return UIView()
   }

--- a/Sources/Provider/CollectionComposer.swift
+++ b/Sources/Provider/CollectionComposer.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class CollectionComposer: ComposedCollectionProvider, CollectionReloadable {
+open class CollectionComposer: SectionSource, CollectionReloadable {
 
   public var identifier: String?
 
@@ -68,6 +68,10 @@ open class CollectionComposer: ComposedCollectionProvider, CollectionReloadable 
 
   open func frame(at: Int) -> CGRect {
     return layout.frame(at: at)
+  }
+
+  open func presenter(at: Int) -> CollectionPresenter? {
+    return presenter
   }
 
   open func willReload() {

--- a/Sources/Provider/CollectionComposer.swift
+++ b/Sources/Provider/CollectionComposer.swift
@@ -8,7 +8,9 @@
 
 import UIKit
 
-open class CollectionComposer: BaseCollectionProvider {
+open class CollectionComposer: ComposedCollectionProvider, CollectionReloadable {
+
+  public var identifier: String?
 
   public var sections: [AnyCollectionProvider] {
     didSet { setNeedsReload() }
@@ -29,80 +31,58 @@ open class CollectionComposer: BaseCollectionProvider {
     self.presenter = presenter
     self.layout = layout
     self.sections = sections
-    super.init(identifier: identifier)
+    self.identifier = identifier
   }
 
   public convenience init(identifier: String? = nil,
                           layout: CollectionLayout = FlowLayout(),
                           presenter: CollectionPresenter? = nil,
                           _ sections: AnyCollectionProvider...) {
-    self.init(layout: layout, presenter: presenter, sections: sections)
+    self.init(identifier: identifier, layout: layout, presenter: presenter, sections: sections)
   }
 
-  open override var numberOfItems: Int {
+  open var numberOfItems: Int {
     return sections.count
   }
 
-  open override var hasSection: Bool {
-    return true
-  }
-
-  open override func section(at: Int) -> AnyCollectionProvider? {
+  open func section(at: Int) -> AnyCollectionProvider? {
     return sections[at]
   }
 
-  open override func view(at: Int) -> UIView {
-    fatalError()
-  }
-
-  open override func update(view: UIView, at: Int) {
-    fatalError()
-  }
-
-  open override func identifier(at: Int) -> String {
+  open func identifier(at: Int) -> String {
     return sections[at].identifier ?? "\(at)"
   }
 
-  open override func layout(collectionSize: CGSize) {
+  open func layout(collectionSize: CGSize) {
     layout.layout(context: CollectionComposerLayoutContext(collectionSize: collectionSize,
                                                            sections: sections))
   }
 
-  open override var contentSize: CGSize {
+  open var contentSize: CGSize {
     return layout.contentSize
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open func visibleIndexes(visibleFrame: CGRect) -> [Int] {
     return layout.visibleIndexes(visibleFrame: visibleFrame)
   }
 
-  open override func frame(at: Int) -> CGRect {
+  open func frame(at: Int) -> CGRect {
     return layout.frame(at: at)
   }
 
-  open override func presenter(at: Int) -> CollectionPresenter? {
-    fatalError()
-  }
-
-  open override func willReload() {
-    super.willReload()
+  open func willReload() {
     for section in sections {
       section.willReload()
     }
   }
 
-  open override func didReload() {
-    super.didReload()
+  open func didReload() {
     for section in sections {
       section.didReload()
     }
   }
 
-  open override func didTap(view: UIView, at: Int) {
-    fatalError()
-  }
-
-  open override func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
+  open func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
     return reloadable === self || sections.contains(where: { $0.hasReloadable(reloadable) })
   }
 }

--- a/Sources/Provider/CollectionComposer.swift
+++ b/Sources/Provider/CollectionComposer.swift
@@ -22,8 +22,6 @@ open class CollectionComposer: BaseCollectionProvider {
     didSet { setNeedsReload() }
   }
 
-  private var sectionBeginIndex: [Int] = []
-
   public init(identifier: String? = nil,
               layout: CollectionLayout = FlowLayout(),
               presenter: CollectionPresenter? = nil,
@@ -41,29 +39,28 @@ open class CollectionComposer: BaseCollectionProvider {
     self.init(layout: layout, presenter: presenter, sections: sections)
   }
 
-  func indexPath(_ index: Int) -> (Int, Int) {
-    let sectionIndex = sectionBeginIndex.binarySearch { $0 <= index } - 1
-    return (sectionIndex, index - sectionBeginIndex[sectionIndex])
+  open override var numberOfItems: Int {
+    return sections.count
   }
 
-  open override var numberOfItems: Int {
-    return (sectionBeginIndex.last ?? 0) + (sections.last?.numberOfItems ?? 0)
+  open override var hasSection: Bool {
+    return true
+  }
+
+  open override func section(at: Int) -> AnyCollectionProvider? {
+    return sections[at]
   }
 
   open override func view(at: Int) -> UIView {
-    let (sectionIndex, item) = indexPath(at)
-    return sections[sectionIndex].view(at: item)
+    fatalError()
   }
 
   open override func update(view: UIView, at: Int) {
-    let (sectionIndex, item) = indexPath(at)
-    sections[sectionIndex].update(view: view, at: item)
+    fatalError()
   }
 
   open override func identifier(at: Int) -> String {
-    let (sectionIndex, item) = indexPath(at)
-    let sectionIdentifier = sections[sectionIndex].identifier ?? "\(sectionIndex)"
-    return "\(sectionIdentifier)." + sections[sectionIndex].identifier(at: item)
+    return sections[at].identifier ?? "\(at)"
   }
 
   open override func layout(collectionSize: CGSize) {
@@ -76,47 +73,21 @@ open class CollectionComposer: BaseCollectionProvider {
   }
 
   open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    var visible = [Int]()
-    for sectionIndex in layout.visibleIndexes(visibleFrame: visibleFrame) {
-      let sectionFrame = layout.frame(at: sectionIndex)
-      let intersectFrame = visibleFrame.intersection(sectionFrame)
-      let visibleFrameForCell = CGRect(origin: intersectFrame.origin - sectionFrame.origin, size: intersectFrame.size)
-      let sectionVisible = sections[sectionIndex].visibleIndexes(visibleFrame: visibleFrameForCell)
-      let beginIndex = sectionBeginIndex[sectionIndex]
-      for item in sectionVisible {
-        visible.append(item + beginIndex)
-      }
-    }
-    return visible
+    return layout.visibleIndexes(visibleFrame: visibleFrame)
   }
 
   open override func frame(at: Int) -> CGRect {
-    let (sectionIndex, item) = indexPath(at)
-    var frame = sections[sectionIndex].frame(at: item)
-    frame.origin += layout.frame(at: sectionIndex).origin
-    return frame
+    return layout.frame(at: at)
   }
 
   open override func presenter(at: Int) -> CollectionPresenter? {
-    let (sectionIndex, item) = indexPath(at)
-    return sections[sectionIndex].presenter(at: item) ?? presenter
+    fatalError()
   }
 
   open override func willReload() {
     super.willReload()
     for section in sections {
       section.willReload()
-    }
-    prepareForReload()
-  }
-
-  internal func prepareForReload() {
-    sectionBeginIndex = []
-    sectionBeginIndex.reserveCapacity(sections.count)
-    var count = 0
-    for section in sections {
-      sectionBeginIndex.append(count)
-      count += section.numberOfItems
     }
   }
 
@@ -128,8 +99,7 @@ open class CollectionComposer: BaseCollectionProvider {
   }
 
   open override func didTap(view: UIView, at: Int) {
-    let (sectionIndex, item) = indexPath(at)
-    sections[sectionIndex].didTap(view: view, at: item)
+    fatalError()
   }
 
   open override func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {

--- a/Sources/Provider/CollectionComposer.swift
+++ b/Sources/Provider/CollectionComposer.swift
@@ -21,7 +21,7 @@ open class CollectionComposer: BaseCollectionProvider {
     }
   }
 
-  public var layout: CollectionLayout<AnyCollectionProvider> {
+  public var layout: CollectionLayout {
     didSet {
       setNeedsReload()
     }
@@ -31,7 +31,7 @@ open class CollectionComposer: BaseCollectionProvider {
   private var dataProvider: ArrayDataProvider<AnyCollectionProvider>
 
   public init(identifier: String? = nil,
-              layout: CollectionLayout<AnyCollectionProvider> = FlowLayout(),
+              layout: CollectionLayout = FlowLayout(),
               presenter: CollectionPresenter? = nil,
               sections: [AnyCollectionProvider]) {
     self.presenter = presenter
@@ -43,7 +43,7 @@ open class CollectionComposer: BaseCollectionProvider {
   }
 
   public convenience init(identifier: String? = nil,
-                          layout: CollectionLayout<AnyCollectionProvider> = FlowLayout(),
+                          layout: CollectionLayout = FlowLayout(),
                           presenter: CollectionPresenter? = nil,
                           _ sections: AnyCollectionProvider...) {
     self.init(layout: layout, presenter: presenter, sections: sections)
@@ -75,13 +75,12 @@ open class CollectionComposer: BaseCollectionProvider {
   }
 
   open override func layout(collectionSize: CGSize) {
-    layout.layout(
-      collectionSize: collectionSize,
-      dataProvider: dataProvider,
-      sizeProvider: { (_, data, collectionSize) in
-        data.layout(collectionSize: collectionSize)
-        return data.contentSize
-      })
+    layout.layout(context: CollectionProviderLayoutContext(collectionSize: collectionSize,
+                                                           dataProvider: dataProvider,
+                                                           sizeProvider: { (_, data, collectionSize) in
+      data.layout(collectionSize: collectionSize)
+      return data.contentSize
+    }))
   }
 
   open override var contentSize: CGSize {

--- a/Sources/Provider/CollectionHeaderComposer.swift
+++ b/Sources/Provider/CollectionHeaderComposer.swift
@@ -1,0 +1,170 @@
+//
+//  CollectionHeaderComposer.swift
+//  CollectionKit
+//
+//  Created by Luke Zhao on 2018-06-09.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+open class CollectionHeaderComposer<HeaderView: UIView>: SectionSource, ViewSource, CollectionReloadable {
+
+  public typealias HeaderData = (index: Int, section: AnyCollectionProvider)
+  public typealias HeaderViewProvider = CollectionViewProvider<HeaderData, HeaderView>
+  public typealias HeaderSizeProvider = CollectionSizeProvider<HeaderData>
+
+  struct CollectionHeaderComposerLayoutContext: LayoutContext {
+    var collectionSize: CGSize
+    var sections: [AnyCollectionProvider]
+    var headerViewProvider: HeaderViewProvider
+    var headerSizeProvider: HeaderSizeProvider
+
+    var numberOfItems: Int {
+      return sections.count * 2
+    }
+    func data(at: Int) -> Any {
+      if at % 2 == 0 {
+        return HeaderData(index: at / 2, section: sections[at / 2])
+      } else {
+        return sections[at / 2]
+      }
+    }
+    func identifier(at: Int) -> String {
+      let sectionIdentifier = sections[at / 2].identifier ?? "\(at)"
+      if at % 2 == 0 {
+        return sectionIdentifier + "-header"
+      } else {
+        return sectionIdentifier
+      }
+    }
+    func size(at: Int, collectionSize: CGSize) -> CGSize {
+      if at % 2 == 0 {
+        return headerSizeProvider(at / 2, data(at: at) as! HeaderData, collectionSize)
+      } else {
+        sections[at / 2].layout(collectionSize: collectionSize)
+        return sections[at / 2].contentSize
+      }
+    }
+  }
+
+  public var identifier: String?
+
+  public var sections: [AnyCollectionProvider] {
+    didSet { setNeedsReload() }
+  }
+
+  public var presenter: CollectionPresenter? {
+    didSet { setNeedsReload() }
+  }
+
+  public var layout: CollectionLayout {
+    didSet { setNeedsReload() }
+  }
+
+  public var headerViewProvider: HeaderViewProvider {
+    didSet { setNeedsReload() }
+  }
+
+  public var headerSizeProvider: HeaderSizeProvider {
+    didSet { setNeedsReload() }
+  }
+
+  public init(identifier: String? = nil,
+              layout: CollectionLayout = FlowLayout(),
+              presenter: CollectionPresenter? = nil,
+              headerViewProvider: HeaderViewProvider,
+              headerSizeProvider: @escaping HeaderSizeProvider,
+              sections: [AnyCollectionProvider]) {
+    self.presenter = presenter
+    self.layout = layout
+    self.sections = sections
+    self.identifier = identifier
+    self.headerViewProvider = headerViewProvider
+    self.headerSizeProvider = headerSizeProvider
+  }
+
+  open var numberOfItems: Int {
+    return sections.count * 2
+  }
+
+  open func section(at: Int) -> AnyCollectionProvider? {
+    if at % 2 == 0 {
+      return nil
+    } else {
+      return sections[at / 2]
+    }
+  }
+
+  open func identifier(at: Int) -> String {
+    let sectionIdentifier = sections[at / 2].identifier ?? "\(at)"
+    if at % 2 == 0 {
+      return sectionIdentifier + "-header"
+    } else {
+      return sectionIdentifier
+    }
+  }
+
+  open func layout(collectionSize: CGSize) {
+    layout.layout(context:
+      CollectionHeaderComposerLayoutContext(
+        collectionSize: collectionSize,
+        sections: sections,
+        headerViewProvider: headerViewProvider,
+        headerSizeProvider: headerSizeProvider
+    ))
+  }
+
+  open var contentSize: CGSize {
+    return layout.contentSize
+  }
+
+  open func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+    return layout.visibleIndexes(visibleFrame: visibleFrame)
+  }
+
+  open func frame(at: Int) -> CGRect {
+    return layout.frame(at: at)
+  }
+
+  open func presenter(at: Int) -> CollectionPresenter? {
+    return presenter
+  }
+
+  public func view(at: Int) -> UIView {
+    let index = at / 2
+    return headerViewProvider.view(data: HeaderData(index: index, section: sections[index]), index: index)
+  }
+
+  public func update(view: UIView, at: Int) {
+    let index = at / 2
+    headerViewProvider.update(view: view as! HeaderView,
+                              data: HeaderData(index: index, section: sections[index]),
+                              index: index)
+  }
+
+  public func didTap(view: UIView, at: Int) {
+    // TODO: CollectionHeaderProvider doesn't support tap yet
+    // Need to cleanup tapHandler first.
+  }
+
+  open func willReload() {
+    for section in sections {
+      section.willReload()
+    }
+  }
+
+  open func didReload() {
+    for section in sections {
+      section.didReload()
+    }
+  }
+
+  open func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
+    return reloadable === self || sections.contains(where: { $0.hasReloadable(reloadable) })
+  }
+
+  public func flattenedProvider() -> ViewSource {
+    return FlattenedProvider(provider: self)
+  }
+}

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -12,7 +12,7 @@ public func defaultSizeProvider<Data>(at: Int, data: Data, collectionSize: CGSiz
   return collectionSize
 }
 
-open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
+open class CollectionProvider<Data, View: UIView>: ViewOnlyCollectionProvider, CollectionReloadable {
   public typealias DataProvider = CollectionDataProvider<Data>
   public typealias ViewProvider = CollectionViewProvider<Data, View>
   public typealias Layout = CollectionLayout
@@ -20,6 +20,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
   public typealias Presenter = CollectionPresenter
   public typealias TapHandler = (View, Int, DataProvider) -> Void
 
+  public var identifier: String?
   public var dataProvider: DataProvider { didSet { setNeedsReload() } }
   public var viewProvider: ViewProvider { didSet { setNeedsReload() } }
   public var layout: Layout = FlowLayout() { didSet { setNeedsReload() } }
@@ -47,7 +48,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     self.willReloadHandler = willReloadHandler
     self.didReloadHandler = didReloadHandler
     self.tapHandler = tapHandler
-    super.init(identifier: identifier)
+    self.identifier = identifier
   }
 
   public init(identifier: String? = nil,
@@ -68,7 +69,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     self.willReloadHandler = willReloadHandler
     self.didReloadHandler = didReloadHandler
     self.tapHandler = tapHandler
-    super.init(identifier: identifier)
+    self.identifier = identifier
   }
 
   public init(identifier: String? = nil,
@@ -89,51 +90,48 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     self.willReloadHandler = willReloadHandler
     self.didReloadHandler = didReloadHandler
     self.tapHandler = tapHandler
-    super.init(identifier: identifier)
+    self.identifier = identifier
   }
 
-  // MARK: - Override Methods
-  open override var numberOfItems: Int {
+  open var numberOfItems: Int {
     return dataProvider.numberOfItems
   }
-  open override func view(at: Int) -> UIView {
+  open func view(at: Int) -> UIView {
     return viewProvider.view(data: dataProvider.data(at: at), index: at)
   }
-  open override func update(view: UIView, at: Int) {
+  open func update(view: UIView, at: Int) {
     viewProvider.update(view: view as! View, data: dataProvider.data(at: at), index: at)
   }
-  open override func identifier(at: Int) -> String {
+  open func identifier(at: Int) -> String {
     return dataProvider.identifier(at: at)
   }
-  open override func layout(collectionSize: CGSize) {
+  open func layout(collectionSize: CGSize) {
     layout.layout(context: CollectionProviderLayoutContext(collectionSize: collectionSize,
                                                            dataProvider: dataProvider,
                                                            sizeProvider: sizeProvider))
   }
-  open override var contentSize: CGSize {
+  open var contentSize: CGSize {
     return layout.contentSize
   }
-  open override func frame(at: Int) -> CGRect {
+  open func frame(at: Int) -> CGRect {
     return layout.frame(at: at)
   }
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open func visibleIndexes(visibleFrame: CGRect) -> [Int] {
     return layout.visibleIndexes(visibleFrame: visibleFrame)
   }
-  open override func presenter(at: Int) -> CollectionPresenter? {
+  open func presenter(at: Int) -> CollectionPresenter? {
     return presenter
   }
-  open override func willReload() {
-    super.willReload()
+  open func willReload() {
     willReloadHandler?()
   }
-  open override func didReload() {
-    super.didReload()
+  open func didReload() {
     didReloadHandler?()
   }
-  open override func didTap(view: UIView, at: Int) {
+  open func didTap(view: UIView, at: Int) {
     tapHandler?(view as! View, at, dataProvider)
   }
-  open override func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
+  open func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
     return reloadable === self || reloadable === dataProvider
   }
 }

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -12,7 +12,7 @@ public func defaultSizeProvider<Data>(at: Int, data: Data, collectionSize: CGSiz
   return collectionSize
 }
 
-open class CollectionProvider<Data, View: UIView>: ViewOnlyCollectionProvider, CollectionReloadable {
+open class CollectionProvider<Data, View: UIView>: ViewSource, CollectionReloadable {
   public typealias DataProvider = CollectionDataProvider<Data>
   public typealias ViewProvider = CollectionViewProvider<Data, View>
   public typealias Layout = CollectionLayout

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -15,14 +15,14 @@ public func defaultSizeProvider<Data>(at: Int, data: Data, collectionSize: CGSiz
 open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
   public typealias DataProvider = CollectionDataProvider<Data>
   public typealias ViewProvider = CollectionViewProvider<Data, View>
-  public typealias Layout = CollectionLayout<Data>
+  public typealias Layout = CollectionLayout
   public typealias SizeProvider = CollectionSizeProvider<Data>
   public typealias Presenter = CollectionPresenter
   public typealias TapHandler = (View, Int, DataProvider) -> Void
 
   public var dataProvider: DataProvider { didSet { setNeedsReload() } }
   public var viewProvider: ViewProvider { didSet { setNeedsReload() } }
-  public var layout: Layout = FlowLayout<Data>() { didSet { setNeedsReload() } }
+  public var layout: Layout = FlowLayout() { didSet { setNeedsReload() } }
   public var sizeProvider: SizeProvider = defaultSizeProvider { didSet { setNeedsReload() } }
   public var presenter: Presenter? { didSet { setNeedsReload() } }
 
@@ -33,7 +33,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
   public init(identifier: String? = nil,
               dataProvider: DataProvider,
               viewProvider: ViewProvider,
-              layout: Layout = FlowLayout<Data>(),
+              layout: Layout = FlowLayout(),
               sizeProvider: @escaping SizeProvider = defaultSizeProvider,
               presenter: Presenter? = nil,
               willReloadHandler: (() -> Void)? = nil,
@@ -54,7 +54,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
               dataProvider: DataProvider,
               viewGenerator: ((Data, Int) -> View)? = nil,
               viewUpdater: @escaping (View, Data, Int) -> Void,
-              layout: Layout = FlowLayout<Data>(),
+              layout: Layout = FlowLayout(),
               sizeProvider: @escaping SizeProvider = defaultSizeProvider,
               presenter: Presenter? = nil,
               willReloadHandler: (() -> Void)? = nil,
@@ -75,7 +75,7 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
               data: [Data],
               viewGenerator: ((Data, Int) -> View)? = nil,
               viewUpdater: @escaping (View, Data, Int) -> Void,
-              layout: Layout = FlowLayout<Data>(),
+              layout: Layout = FlowLayout(),
               sizeProvider: @escaping SizeProvider = defaultSizeProvider,
               presenter: Presenter? = nil,
               willReloadHandler: (() -> Void)? = nil,
@@ -106,7 +106,9 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     return dataProvider.identifier(at: at)
   }
   open override func layout(collectionSize: CGSize) {
-    layout.layout(collectionSize: collectionSize, dataProvider: dataProvider, sizeProvider: sizeProvider)
+    layout.layout(context: CollectionProviderLayoutContext(collectionSize: collectionSize,
+                                                           dataProvider: dataProvider,
+                                                           sizeProvider: sizeProvider))
   }
   open override var contentSize: CGSize {
     return layout.contentSize

--- a/Sources/Provider/CollectionProvider.swift
+++ b/Sources/Provider/CollectionProvider.swift
@@ -137,3 +137,22 @@ open class CollectionProvider<Data, View: UIView>: BaseCollectionProvider {
     return reloadable === self || reloadable === dataProvider
   }
 }
+
+struct CollectionProviderLayoutContext<Data>: LayoutContext {
+  var collectionSize: CGSize
+  var dataProvider: CollectionDataProvider<Data>
+  var sizeProvider: CollectionSizeProvider<Data>
+
+  var numberOfItems: Int {
+    return dataProvider.numberOfItems
+  }
+  func data(at: Int) -> Any {
+    return dataProvider.data(at: at)
+  }
+  func identifier(at: Int) -> String {
+    return dataProvider.identifier(at: at)
+  }
+  func size(at: Int, collectionSize: CGSize) -> CGSize {
+    return sizeProvider(at, dataProvider.data(at: at), collectionSize)
+  }
+}

--- a/Sources/Provider/EmptyCollectionProvider.swift
+++ b/Sources/Provider/EmptyCollectionProvider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class BaseCollectionProvider: AnyCollectionProvider {
+open class EmptyCollectionProvider: ViewOnlyCollectionProvider, CollectionReloadable {
   public var identifier: String?
 
   public init(identifier: String? = nil) {
@@ -17,12 +17,6 @@ open class BaseCollectionProvider: AnyCollectionProvider {
 
   open var numberOfItems: Int {
     return 0
-  }
-  public var hasSection: Bool {
-    return false
-  }
-  public func section(at: Int) -> AnyCollectionProvider? {
-    return nil
   }
   open func view(at: Int) -> UIView {
     return UIView()
@@ -47,21 +41,11 @@ open class BaseCollectionProvider: AnyCollectionProvider {
     return nil
   }
 
-  open func willReload() {
-    needsReload = false
-  }
+  open func willReload() {}
   open func didReload() {}
   open func didTap(view: UIView, at: Int) {}
 
   open func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
     return reloadable === self
-  }
-
-  public private(set) var needsReload = false
-  public func setNeedsReload() {
-    if !needsReload {
-      needsReload = true
-      collectionView?.setNeedsReload()
-    }
   }
 }

--- a/Sources/Provider/EmptyCollectionProvider.swift
+++ b/Sources/Provider/EmptyCollectionProvider.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-open class EmptyCollectionProvider: ViewOnlyCollectionProvider, CollectionReloadable {
+open class EmptyCollectionProvider: ViewSource, CollectionReloadable {
   public var identifier: String?
 
   public init(identifier: String? = nil) {

--- a/Sources/Provider/FlattenedProvider.swift
+++ b/Sources/Provider/FlattenedProvider.swift
@@ -8,19 +8,19 @@
 
 import UIKit
 
-struct FlattenedProvider: ViewOnlyCollectionProvider {
+struct FlattenedProvider: ViewSource {
 
-  var provider: ComposedCollectionProvider
+  var provider: SectionSource
 
-  private var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)]
+  private var childSections: [(beginIndex: Int, sectionData: ViewSource?)]
 
-  init(provider: ComposedCollectionProvider) {
+  init(provider: SectionSource) {
     self.provider = provider
-    var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)] = []
+    var childSections: [(beginIndex: Int, sectionData: ViewSource?)] = []
     childSections.reserveCapacity(provider.numberOfItems)
     var count = 0
     for i in 0..<provider.numberOfItems {
-      let sectionData: ViewOnlyCollectionProvider?
+      let sectionData: ViewSource?
       if let section = provider.section(at: i) {
         sectionData = section.flattenedProvider()
       } else {
@@ -37,13 +37,13 @@ struct FlattenedProvider: ViewOnlyCollectionProvider {
     return (sectionIndex, index - childSections[sectionIndex].beginIndex)
   }
 
-  func apply<T>(_ index: Int, with: (ViewOnlyCollectionProvider, Int) -> T) -> T {
+  func apply<T>(_ index: Int, with: (ViewSource, Int) -> T) -> T {
     let (sectionIndex, item) = indexPath(index)
     if let sectionData = childSections[sectionIndex].sectionData {
       return with(sectionData, item)
     } else {
-      assert(provider is ViewOnlyCollectionProvider, "Provider don't support view index")
-      return with(provider as! ViewOnlyCollectionProvider, sectionIndex)
+      assert(provider is ViewSource, "Provider don't support view index")
+      return with(provider as! ViewSource, sectionIndex)
     }
   }
 
@@ -117,7 +117,7 @@ struct FlattenedProvider: ViewOnlyCollectionProvider {
   func presenter(at: Int) -> CollectionPresenter? {
     return apply(at) {
       $0.presenter(at: $1)
-    }
+    } ?? provider.presenter(at: at)
   }
 
   func willReload() {

--- a/Sources/Provider/FlattenedProvider.swift
+++ b/Sources/Provider/FlattenedProvider.swift
@@ -1,0 +1,140 @@
+//
+//  FlattenedProvider.swift
+//  CollectionKit
+//
+//  Created by Luke Zhao on 2018-06-08.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+struct FlattenedProvider: ViewOnlyCollectionProvider {
+
+  var provider: ComposedCollectionProvider
+
+  private var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)]
+
+  init(provider: ComposedCollectionProvider) {
+    self.provider = provider
+    var childSections: [(beginIndex: Int, sectionData: ViewOnlyCollectionProvider?)] = []
+    childSections.reserveCapacity(provider.numberOfItems)
+    var count = 0
+    for i in 0..<provider.numberOfItems {
+      let sectionData: ViewOnlyCollectionProvider?
+      if let section = provider.section(at: i) {
+        sectionData = section.flattenedProvider()
+      } else {
+        sectionData = nil
+      }
+      childSections.append((beginIndex: count, sectionData: sectionData))
+      count += sectionData?.numberOfItems ?? 1
+    }
+    self.childSections = childSections
+  }
+
+  func indexPath(_ index: Int) -> (Int, Int) {
+    let sectionIndex = childSections.binarySearch { $0.beginIndex <= index } - 1
+    return (sectionIndex, index - childSections[sectionIndex].beginIndex)
+  }
+
+  func apply<T>(_ index: Int, with: (ViewOnlyCollectionProvider, Int) -> T) -> T {
+    let (sectionIndex, item) = indexPath(index)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      return with(sectionData, item)
+    } else {
+      assert(provider is ViewOnlyCollectionProvider, "Provider don't support view index")
+      return with(provider as! ViewOnlyCollectionProvider, sectionIndex)
+    }
+  }
+
+  var identifier: String? {
+    return provider.identifier
+  }
+
+  var numberOfItems: Int {
+    return (childSections.last?.beginIndex ?? 0) + (childSections.last?.sectionData?.numberOfItems ?? 0)
+  }
+
+  func view(at: Int) -> UIView {
+    return apply(at) {
+      $0.view(at: $1)
+    }
+  }
+
+  func update(view: UIView, at: Int) {
+    return apply(at) {
+      $0.update(view: view, at: $1)
+    }
+  }
+
+  func identifier(at: Int) -> String {
+    let (sectionIndex, item) = indexPath(at)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      return provider.identifier(at: sectionIndex) + sectionData.identifier(at: item)
+    } else {
+      return provider.identifier(at: sectionIndex)
+    }
+  }
+
+  func layout(collectionSize: CGSize) {
+    provider.layout(collectionSize: collectionSize)
+  }
+
+  var contentSize: CGSize {
+    return provider.contentSize
+  }
+
+  func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+    var visible = [Int]()
+    for sectionIndex in provider.visibleIndexes(visibleFrame: visibleFrame) {
+      let beginIndex = childSections[sectionIndex].beginIndex
+      if let sectionData = childSections[sectionIndex].sectionData {
+        let sectionFrame = provider.frame(at: sectionIndex)
+        let intersectFrame = visibleFrame.intersection(sectionFrame)
+        let visibleFrameForCell = CGRect(origin: intersectFrame.origin - sectionFrame.origin, size: intersectFrame.size)
+        let sectionVisible = sectionData.visibleIndexes(visibleFrame: visibleFrameForCell)
+        for item in sectionVisible {
+          visible.append(item + beginIndex)
+        }
+      } else {
+        visible.append(beginIndex)
+      }
+    }
+    return visible
+  }
+
+  func frame(at: Int) -> CGRect {
+    let (sectionIndex, item) = indexPath(at)
+    if let sectionData = childSections[sectionIndex].sectionData {
+      var frame = sectionData.frame(at: item)
+      frame.origin += provider.frame(at: sectionIndex).origin
+      return frame
+    } else {
+      return provider.frame(at: sectionIndex)
+    }
+  }
+
+  func presenter(at: Int) -> CollectionPresenter? {
+    return apply(at) {
+      $0.presenter(at: $1)
+    }
+  }
+
+  func willReload() {
+    provider.willReload()
+  }
+
+  func didReload() {
+    provider.didReload()
+  }
+
+  func didTap(view: UIView, at: Int) {
+    return apply(at) {
+      $0.didTap(view: view, at: $1)
+    }
+  }
+
+  func hasReloadable(_ reloadable: CollectionReloadable) -> Bool {
+    return provider.hasReloadable(reloadable)
+  }
+}

--- a/Sources/ViewProvider/AnyCollectionViewProvider.swift
+++ b/Sources/ViewProvider/AnyCollectionViewProvider.swift
@@ -1,0 +1,14 @@
+//
+//  AnyCollectionViewProvider.swift
+//  CollectionKitExample
+//
+//  Created by Luke Zhao on 2018-06-06.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+public protocol AnyCollectionViewProvider {
+  func anyView(data: Any, index: Int) -> UIView
+  func anyUpdate(view: UIView, data: Any, index: Int)
+}

--- a/Sources/ViewProvider/CollectionViewProvider.swift
+++ b/Sources/ViewProvider/CollectionViewProvider.swift
@@ -24,3 +24,13 @@ open class CollectionViewProvider<Data, View: UIView> {
 
   public init() {}
 }
+
+extension CollectionViewProvider: AnyCollectionViewProvider {
+  public final func anyView(data: Any, index: Int) -> UIView {
+    return view(data: data as! Data, index: index)
+  }
+
+  public final func anyUpdate(view: UIView, data: Any, index: Int) {
+    return update(view: view as! View, data: data as! Data, index: index)
+  }
+}

--- a/Sources/ViewProvider/ViewProviderComposer.swift
+++ b/Sources/ViewProvider/ViewProviderComposer.swift
@@ -1,0 +1,25 @@
+//
+//  ViewProviderComposer.swift
+//  CollectionKit
+//
+//  Created by Luke Zhao on 2018-06-06.
+//  Copyright © 2018 lkzhao. All rights reserved.
+//
+
+import UIKit
+
+public class ViewProviderComposer<Data>: CollectionViewProvider<Data, UIView> {
+  public var viewProviderSelector: (Data) -> AnyCollectionViewProvider
+
+  public init(viewProviderSelector: @escaping (Data) -> AnyCollectionViewProvider) {
+    self.viewProviderSelector = viewProviderSelector
+  }
+
+  public override func update(view: UIView, data: Data, index: Int) {
+    viewProviderSelector(data).anyUpdate(view: view, data: data, index: index)
+  }
+
+  public override func view(data: Data, index: Int) -> UIView {
+    return viewProviderSelector(data).anyView(data: data, index: index)
+  }
+}


### PR DESCRIPTION
CollectionKit becomes my personal favourite framework for building iOS app. 
It is definitely a huge time saver. 

To make it even better, here are some more improvements that I would like to add to the framework.

**Note** this version won't be source compatible with 1.3.0. It is easy to migrate though. A migration guide will be written before releasing 2.0.0.

Focus of 2.0.0 will be towards API cleanliness & solves pain points with v1.0+

Main feature planned for 2.0.0:
1. Sticky Header Support
1. Better support for mixed data type
1. Layout cleanup
1. Internal architecture cleanup for future features

This PR introduces the first set of changes towards 2.0.0:
1. **Layout** becomes data independent.
    * previously, `FlowLayout<Int> -> FlowLayout`
1. **Layout** only receives an abstract object **LayoutContent** during layout, instead of receiving `dataProvider` & `sizeProvider`.
1. Move flattening step out of **CollectionComposer** so that it is easy to create other composer variants.
1. A new **CollectionHeaderComposer** to support header & sticky header
1. Add **HeaderExampleViewController** to demonstrate header & sticky header support
1. Add **ViewProviderComposer** to better support mixed data type for a single **CollectionProvider**
    * Not entirely sure this is the best solution. Advices welcome.

This PR is still WIP. Posting for review first.



