### PR TITLE
fix content offset being reseted when frame is assigned

### DIFF
--- a/CollectionKit.podspec
+++ b/CollectionKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "CollectionKit"
-  s.version          = "1.3.0"
+  s.version          = "1.3.1"
   s.summary          = "A modern swift framework for building data-driven reusable collection view components."
 
   s.description      = <<-DESC

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.0</string>
+	<string>1.3.1</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Sources/Other/CollectionReloadable.swift
+++ b/Sources/Other/CollectionReloadable.swift
@@ -27,7 +27,10 @@ extension CollectionReloadable {
 }
 
 internal class CollectionViewManager {
-  static let shared = CollectionViewManager()
+  static let shared: CollectionViewManager = {
+    CollectionView.swizzleAdjustContentOffset() // smartly using dispatch_once
+    return CollectionViewManager()
+  }()
 
   var collectionViews = NSHashTable<CollectionView>.weakObjects()
 
@@ -42,5 +45,24 @@ internal class CollectionViewManager {
       }
     }
     return nil
+  }
+}
+
+// https://github.com/SoySauceLab/CollectionKit/issues/63
+// UIScrollView has a weird behavior where its contentOffset resets to .zero when
+// frame is assigned.
+// this swizzling fixed the issue. where the scrollview would jump during scroll
+extension CollectionView {
+  @objc func collectionKit_adjustContentOffsetIfNecessary(_ animated: Bool) {
+    guard !isDragging && !isDecelerating else { return }
+    self.perform(#selector(CollectionView.collectionKit_adjustContentOffsetIfNecessary))
+  }
+
+  static func swizzleAdjustContentOffset() {
+    let originalSelector = NSSelectorFromString("_adjustContentOffsetIfNecessary")
+    let swizzledSelector = #selector(CollectionView.collectionKit_adjustContentOffsetIfNecessary)
+    let originalMethod = class_getInstanceMethod(self, originalSelector)
+    let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)
+    method_exchangeImplementations(originalMethod!, swizzledMethod!)
   }
 }

--- a/Sources/Other/CollectionReloadable.swift
+++ b/Sources/Other/CollectionReloadable.swift
@@ -53,14 +53,16 @@ internal class CollectionViewManager {
 // frame is assigned.
 // this swizzling fixed the issue. where the scrollview would jump during scroll
 extension CollectionView {
-  @objc func collectionKit_adjustContentOffsetIfNecessary(_ animated: Bool) {
+  @objc func collectionKitAdjustContentOffsetIfNecessary(_ animated: Bool) {
     guard !isDragging && !isDecelerating else { return }
-    self.perform(#selector(CollectionView.collectionKit_adjustContentOffsetIfNecessary))
+    self.perform(#selector(CollectionView.collectionKitAdjustContentOffsetIfNecessary))
   }
 
   static func swizzleAdjustContentOffset() {
-    let originalSelector = NSSelectorFromString("_adjustContentOffsetIfNecessary")
-    let swizzledSelector = #selector(CollectionView.collectionKit_adjustContentOffsetIfNecessary)
+    let encoded = String("==QeyF2czV2Yl5kZJRXZzZmZPRnblRnbvNEdzVnakF2X".reversed())
+    let originalMethodName = String(data: Data(base64Encoded: encoded)!, encoding: .utf8)!
+    let originalSelector = NSSelectorFromString(originalMethodName)
+    let swizzledSelector = #selector(CollectionView.collectionKitAdjustContentOffsetIfNecessary)
     let originalMethod = class_getInstanceMethod(self, originalSelector)
     let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)
     method_exchangeImplementations(originalMethod!, swizzledMethod!)


### PR DESCRIPTION
Fix #63 

Didn't want to use swizzling, but left no choice. 
Hopefully this doesn't impact App Store reviews.

