### PR TITLE
Fix unexpected UIScrollView behavior

### DIFF
--- a/Sources/Other/CollectionReloadable.swift
+++ b/Sources/Other/CollectionReloadable.swift
@@ -57,7 +57,7 @@ internal class CollectionViewManager {
 // this swizzling fixed the issue. where the scrollview would jump during scroll
 extension UIScrollView {
   @objc func collectionKitAdjustContentOffsetIfNecessary(_ animated: Bool) {
-    guard !isDragging && !isDecelerating else { return }
+    guard !(self is CollectionView) || !isDragging && !isDecelerating else { return }
     self.perform(#selector(CollectionView.collectionKitAdjustContentOffsetIfNecessary))
   }
 


### PR DESCRIPTION
This change ensures that the swizzled logic only applies to
CollectionView and its subclasses.

I discovered this after experiencing unexpected behavior in an unrelated
UIScrollView subclass after adding a CollectionView to my project.