### PR TITLE
Nested visible frame inset fix

### DIFF
--- a/CollectionKitTests/FlowLayoutSpec.swift
+++ b/CollectionKitTests/FlowLayoutSpec.swift
@@ -49,7 +49,7 @@ class FlowLayoutSpec: QuickSpec {
       it("should not display cells outside of the visible area") {
         let layout = FlowLayout().transposed()
         layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
-        let visible = layout.visible(for: CGRect(x: 50, y: 0, width: 100, height: 50)).indexes
+        let visible = layout.visible(in: CGRect(x: 50, y: 0, width: 100, height: 50)).indexes
         expect(visible).to(equal([1, 2]))
       }
     }

--- a/CollectionKitTests/FlowLayoutSpec.swift
+++ b/CollectionKitTests/FlowLayoutSpec.swift
@@ -49,7 +49,7 @@ class FlowLayoutSpec: QuickSpec {
       it("should not display cells outside of the visible area") {
         let layout = FlowLayout().transposed()
         layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
-        let visible = layout.visibleIndexes(visibleFrame: CGRect(x: 50, y: 0, width: 100, height: 50))
+        let visible = layout.visible(for: CGRect(x: 50, y: 0, width: 100, height: 50)).indexes
         expect(visible).to(equal([1, 2]))
       }
     }

--- a/CollectionKitTests/WaterfallLayoutSpec.swift
+++ b/CollectionKitTests/WaterfallLayoutSpec.swift
@@ -46,7 +46,7 @@ class WaterfallLayoutSpec: QuickSpec {
       it("should not display cells outside of the visible area") {
         let layout = WaterfallLayout()
         layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
-        let visible = layout.visibleIndexes(visibleFrame: CGRect(x: 0, y: 50, width: 100, height: 50))
+        let visible = layout.visible(for: CGRect(x: 0, y: 50, width: 100, height: 50)).indexes
         expect(visible).to(equal([2, 3]))
       }
     }

--- a/CollectionKitTests/WaterfallLayoutSpec.swift
+++ b/CollectionKitTests/WaterfallLayoutSpec.swift
@@ -46,7 +46,7 @@ class WaterfallLayoutSpec: QuickSpec {
       it("should not display cells outside of the visible area") {
         let layout = WaterfallLayout()
         layout.mockLayout(parentSize: (100, 50), (50, 50), (50, 50), (50, 50), (50, 50))
-        let visible = layout.visible(for: CGRect(x: 0, y: 50, width: 100, height: 50)).indexes
+        let visible = layout.visible(in: CGRect(x: 0, y: 50, width: 100, height: 50)).indexes
         expect(visible).to(equal([2, 3]))
       }
     }

--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -158,7 +158,7 @@ open class CollectionView: UIScrollView {
   }
 
   private func _loadCells(forceReload: Bool) {
-    let newIndexes = flattenedProvider.visible(for: visibleFrame).indexes
+    let newIndexes = flattenedProvider.visible(in: visibleFrame).indexes
 
     // optimization: we assume that corresponding identifier for each index doesnt change unless forceReload is true.
     guard forceReload ||

--- a/Sources/CollectionView.swift
+++ b/Sources/CollectionView.swift
@@ -158,7 +158,7 @@ open class CollectionView: UIScrollView {
   }
 
   private func _loadCells(forceReload: Bool) {
-    let newIndexes = flattenedProvider.visibleIndexes(visibleFrame: visibleFrame)
+    let newIndexes = flattenedProvider.visible(for: visibleFrame).indexes
 
     // optimization: we assume that corresponding identifier for each index doesnt change unless forceReload is true.
     guard forceReload ||

--- a/Sources/Layout/InsetLayout.swift
+++ b/Sources/Layout/InsetLayout.swift
@@ -55,8 +55,8 @@ open class InsetLayout: WrapperLayout {
     rootLayout.layout(context: InsetLayoutContext(original: context, insets: insets))
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    return rootLayout.visible(for: visibleFrame.inset(by: -insets))
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(in: visibleFrame.inset(by: -insets))
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/InsetLayout.swift
+++ b/Sources/Layout/InsetLayout.swift
@@ -55,8 +55,8 @@ open class InsetLayout: WrapperLayout {
     rootLayout.layout(context: InsetLayoutContext(original: context, insets: insets))
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return rootLayout.visibleIndexes(visibleFrame: visibleFrame.inset(by: -insets))
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(for: visibleFrame.inset(by: -insets))
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/Layout.swift
+++ b/Sources/Layout/Layout.swift
@@ -38,6 +38,7 @@ extension Layout {
     return InsetLayout(self, insets: insets)
   }
 
+  /// Visible insets in the opposite of the layout direction are doubled
   public func insetVisibleFrame(by insets: UIEdgeInsets) -> VisibleFrameInsetLayout {
     return VisibleFrameInsetLayout(self, insets: insets)
   }

--- a/Sources/Layout/Layout.swift
+++ b/Sources/Layout/Layout.swift
@@ -22,7 +22,7 @@ open class Layout {
     fatalError("Subclass should provide its own layout")
   }
 
-  open func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     fatalError("Subclass should provide its own layout")
   }
 

--- a/Sources/Layout/Layout.swift
+++ b/Sources/Layout/Layout.swift
@@ -22,7 +22,7 @@ open class Layout {
     fatalError("Subclass should provide its own layout")
   }
 
-  open func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  open func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     fatalError("Subclass should provide its own layout")
   }
 

--- a/Sources/Layout/SimpleLayout.swift
+++ b/Sources/Layout/SimpleLayout.swift
@@ -36,7 +36,7 @@ open class SimpleLayout: Layout {
     return frames[at]
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     var result = [Int]()
     for (i, frame) in frames.enumerated() {
       if frame.intersects(visibleFrame) {
@@ -54,7 +54,7 @@ open class VerticalSimpleLayout: SimpleLayout {
     maxFrameLength = frames.max { $0.height < $1.height }?.height ?? 0
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     guard !visibleFrame.isEmptyOrNegative else {
         // When this vertical layout gets called in a
         // section provider with horizontal layout we need
@@ -85,7 +85,7 @@ open class HorizontalSimpleLayout: SimpleLayout {
     maxFrameLength = frames.max { $0.width < $1.width }?.width ?? 0
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     guard !visibleFrame.isEmptyOrNegative else {
         return ([], visibleFrame)
     }

--- a/Sources/Layout/SimpleLayout.swift
+++ b/Sources/Layout/SimpleLayout.swift
@@ -36,14 +36,14 @@ open class SimpleLayout: Layout {
     return frames[at]
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     var result = [Int]()
     for (i, frame) in frames.enumerated() {
       if frame.intersects(visibleFrame) {
         result.append(i)
       }
     }
-    return result
+    return (result, visibleFrame)
   }
 }
 
@@ -54,7 +54,7 @@ open class VerticalSimpleLayout: SimpleLayout {
     maxFrameLength = frames.max { $0.height < $1.height }?.height ?? 0
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     var index = frames.binarySearch { $0.minY < visibleFrame.minY - maxFrameLength }
     var visibleIndexes = [Int]()
     while index < frames.count {
@@ -67,7 +67,7 @@ open class VerticalSimpleLayout: SimpleLayout {
       }
       index += 1
     }
-    return visibleIndexes
+    return (visibleIndexes, visibleFrame)
   }
 }
 
@@ -78,7 +78,7 @@ open class HorizontalSimpleLayout: SimpleLayout {
     maxFrameLength = frames.max { $0.width < $1.width }?.width ?? 0
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     var index = frames.binarySearch { $0.minX < visibleFrame.minX - maxFrameLength }
     var visibleIndexes = [Int]()
     while index < frames.count {
@@ -91,6 +91,6 @@ open class HorizontalSimpleLayout: SimpleLayout {
       }
       index += 1
     }
-    return visibleIndexes
+    return (visibleIndexes, visibleFrame)
   }
 }

--- a/Sources/Layout/SimpleLayout.swift
+++ b/Sources/Layout/SimpleLayout.swift
@@ -55,6 +55,13 @@ open class VerticalSimpleLayout: SimpleLayout {
   }
 
   open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    guard !visibleFrame.isEmptyOrNegative else {
+        // When this vertical layout gets called in a
+        // section provider with horizontal layout we need
+        // to guard here because the optimised index search
+        // here doesn't take the X axes into account.
+      return ([], visibleFrame)
+    }
     var index = frames.binarySearch { $0.minY < visibleFrame.minY - maxFrameLength }
     var visibleIndexes = [Int]()
     while index < frames.count {
@@ -79,6 +86,9 @@ open class HorizontalSimpleLayout: SimpleLayout {
   }
 
   open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    guard !visibleFrame.isEmptyOrNegative else {
+        return ([], visibleFrame)
+    }
     var index = frames.binarySearch { $0.minX < visibleFrame.minX - maxFrameLength }
     var visibleIndexes = [Int]()
     while index < frames.count {
@@ -92,5 +102,13 @@ open class HorizontalSimpleLayout: SimpleLayout {
       index += 1
     }
     return (visibleIndexes, visibleFrame)
+  }
+}
+
+extension CGRect {
+  /// Returns whether a rectangle has zero or less
+  /// width or height, or is a null rectangle.
+  var isEmptyOrNegative: Bool {
+    return isEmpty || size.width < 0 || size.height < 0
   }
 }

--- a/Sources/Layout/StickyLayout.swift
+++ b/Sources/Layout/StickyLayout.swift
@@ -34,17 +34,19 @@ public class StickyLayout: WrapperLayout {
     }
   }
 
-  public override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
+  // TODO: Fix for the new FlattenedProvider.visible(for:)
+  public override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     self.visibleFrame = visibleFrame
     topFrameIndex = stickyFrames.binarySearch { $0.frame.minY < visibleFrame.minY } - 1
     if let index = stickyFrames.get(topFrameIndex)?.index, index >= 0 {
-      var oldVisible = rootLayout.visibleIndexes(visibleFrame: visibleFrame)
-      if let index = oldVisible.index(of: index) {
-        oldVisible.remove(at: index)
+      var oldVisible = rootLayout.visible(for: visibleFrame)
+      if let index = oldVisible.indexes.index(of: index) {
+        oldVisible.indexes.remove(at: index)
       }
-      return oldVisible + [index]
+      oldVisible.indexes += [index]
+      return oldVisible
     }
-    return rootLayout.visibleIndexes(visibleFrame: visibleFrame)
+    return rootLayout.visible(for: visibleFrame)
   }
 
   public override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/StickyLayout.swift
+++ b/Sources/Layout/StickyLayout.swift
@@ -34,19 +34,19 @@ public class StickyLayout: WrapperLayout {
     }
   }
 
-  // TODO: Fix for the new FlattenedProvider.visible(for:)
-  public override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  // TODO: Fix for the new FlattenedProvider.visible(in:)
+  public override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     self.visibleFrame = visibleFrame
     topFrameIndex = stickyFrames.binarySearch { $0.frame.minY < visibleFrame.minY } - 1
     if let index = stickyFrames.get(topFrameIndex)?.index, index >= 0 {
-      var oldVisible = rootLayout.visible(for: visibleFrame)
+      var oldVisible = rootLayout.visible(in: visibleFrame)
       if let index = oldVisible.indexes.index(of: index) {
         oldVisible.indexes.remove(at: index)
       }
       oldVisible.indexes += [index]
       return oldVisible
     }
-    return rootLayout.visible(for: visibleFrame)
+    return rootLayout.visible(in: visibleFrame)
   }
 
   public override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/TransposeLayout.swift
+++ b/Sources/Layout/TransposeLayout.swift
@@ -38,7 +38,8 @@ open class TransposeLayout: WrapperLayout {
   }
 
   open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    return rootLayout.visible(for: visibleFrame.transposed)
+    let visible = rootLayout.visible(for: visibleFrame.transposed)
+    return (visible.indexes, visible.frame.transposed)
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/TransposeLayout.swift
+++ b/Sources/Layout/TransposeLayout.swift
@@ -37,8 +37,8 @@ open class TransposeLayout: WrapperLayout {
     rootLayout.layout(context: TransposeLayoutContext(original: context))
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    let visible = rootLayout.visible(for: visibleFrame.transposed)
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    let visible = rootLayout.visible(in: visibleFrame.transposed)
     return (visible.indexes, visible.frame.transposed)
   }
 

--- a/Sources/Layout/TransposeLayout.swift
+++ b/Sources/Layout/TransposeLayout.swift
@@ -37,8 +37,8 @@ open class TransposeLayout: WrapperLayout {
     rootLayout.layout(context: TransposeLayoutContext(original: context))
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return rootLayout.visibleIndexes(visibleFrame: visibleFrame.transposed)
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(for: visibleFrame.transposed)
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/VisibleFrameInsetLayout.swift
+++ b/Sources/Layout/VisibleFrameInsetLayout.swift
@@ -30,7 +30,7 @@ open class VisibleFrameInsetLayout: WrapperLayout {
     super.layout(context: context)
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return rootLayout.visibleIndexes(visibleFrame: visibleFrame.inset(by: insets))
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(for: visibleFrame.inset(by: insets))
   }
 }

--- a/Sources/Layout/VisibleFrameInsetLayout.swift
+++ b/Sources/Layout/VisibleFrameInsetLayout.swift
@@ -30,7 +30,7 @@ open class VisibleFrameInsetLayout: WrapperLayout {
     super.layout(context: context)
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    return rootLayout.visible(for: visibleFrame.inset(by: insets))
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(in: visibleFrame.inset(by: insets))
   }
 }

--- a/Sources/Layout/WrapperLayout.swift
+++ b/Sources/Layout/WrapperLayout.swift
@@ -23,8 +23,8 @@ open class WrapperLayout: Layout {
     rootLayout.layout(context: context)
   }
 
-  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    return rootLayout.visible(for: visibleFrame)
+  open override func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(in: visibleFrame)
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Layout/WrapperLayout.swift
+++ b/Sources/Layout/WrapperLayout.swift
@@ -23,8 +23,8 @@ open class WrapperLayout: Layout {
     rootLayout.layout(context: context)
   }
 
-  open override func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return rootLayout.visibleIndexes(visibleFrame: visibleFrame)
+  open override func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return rootLayout.visible(for: visibleFrame)
   }
 
   open override func frame(at: Int) -> CGRect {

--- a/Sources/Protocol/LayoutableProvider.swift
+++ b/Sources/Protocol/LayoutableProvider.swift
@@ -21,8 +21,8 @@ extension LayoutableProvider where Self: Provider {
   public func layout(collectionSize: CGSize) {
     internalLayout.layout(context: layoutContext(collectionSize: collectionSize))
   }
-  public func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return internalLayout.visibleIndexes(visibleFrame: visibleFrame)
+  public func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return internalLayout.visible(for: visibleFrame)
   }
   public var contentSize: CGSize {
     return internalLayout.contentSize

--- a/Sources/Protocol/LayoutableProvider.swift
+++ b/Sources/Protocol/LayoutableProvider.swift
@@ -21,8 +21,8 @@ extension LayoutableProvider where Self: Provider {
   public func layout(collectionSize: CGSize) {
     internalLayout.layout(context: layoutContext(collectionSize: collectionSize))
   }
-  public func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    return internalLayout.visible(for: visibleFrame)
+  public func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return internalLayout.visible(in: visibleFrame)
   }
   public var contentSize: CGSize {
     return internalLayout.contentSize

--- a/Sources/Protocol/Provider.swift
+++ b/Sources/Protocol/Provider.swift
@@ -17,7 +17,7 @@ public protocol Provider {
 
   // layout
   func layout(collectionSize: CGSize)
-  func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect)
+  func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect)
   var contentSize: CGSize { get }
   func frame(at: Int) -> CGRect
 

--- a/Sources/Protocol/Provider.swift
+++ b/Sources/Protocol/Provider.swift
@@ -17,7 +17,7 @@ public protocol Provider {
 
   // layout
   func layout(collectionSize: CGSize)
-  func visibleIndexes(visibleFrame: CGRect) -> [Int]
+  func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect)
   var contentSize: CGSize { get }
   func frame(at: Int) -> CGRect
 

--- a/Sources/Provider/EmptyCollectionProvider.swift
+++ b/Sources/Provider/EmptyCollectionProvider.swift
@@ -33,8 +33,8 @@ open class EmptyCollectionProvider: ItemProvider, CollectionReloadable {
   open func frame(at: Int) -> CGRect {
     return .zero
   }
-  open func visibleIndexes(visibleFrame: CGRect) -> [Int] {
-    return [Int]()
+  open func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    return ([Int](), visibleFrame)
   }
 
   open func animator(at: Int) -> Animator? {

--- a/Sources/Provider/EmptyCollectionProvider.swift
+++ b/Sources/Provider/EmptyCollectionProvider.swift
@@ -33,7 +33,7 @@ open class EmptyCollectionProvider: ItemProvider, CollectionReloadable {
   open func frame(at: Int) -> CGRect {
     return .zero
   }
-  open func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+  open func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     return ([Int](), visibleFrame)
   }
 

--- a/Sources/Provider/FlattenedProvider.swift
+++ b/Sources/Provider/FlattenedProvider.swift
@@ -84,8 +84,8 @@ struct FlattenedProvider: ItemProvider {
     return provider.contentSize
   }
 
-  func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
-    let visible = provider.visible(for: visibleFrame)
+  func visible(in visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
+    let visible = provider.visible(in: visibleFrame)
     // sort child sections by the indexes from layout
     let sections = Array(0..<childSections.count).sorted(by: visible.indexes)
     // load indexes from all child sections
@@ -106,7 +106,7 @@ struct FlattenedProvider: ItemProvider {
       let minRight = min(visible.frame.maxX, section.maxX)
       let visibleFrameForCell = CGRect(x: x, y: y, width: minRight - maxLeft, height: minBottom - maxTop)
       let child = childSections[index]
-      let childVisible = child.sectionData?.visible(for: visibleFrameForCell)
+      let childVisible = child.sectionData?.visible(in: visibleFrameForCell)
       let childIndexes = childVisible?.indexes ?? [0]
       return childIndexes.map { $0 + child.beginIndex }
     }

--- a/Sources/Provider/FlattenedProvider.swift
+++ b/Sources/Provider/FlattenedProvider.swift
@@ -84,7 +84,7 @@ struct FlattenedProvider: ItemProvider {
     return provider.contentSize
   }
 
-  func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect)  {
+  func visible(for visibleFrame: CGRect) -> (indexes: [Int], frame: CGRect) {
     let visible = provider.visible(for: visibleFrame)
     // sort child sections by the indexes from layout
     let sections = Array(0..<childSections.count).sorted(by: visible.indexes)
@@ -102,8 +102,8 @@ struct FlattenedProvider: ItemProvider {
       let y = max(0, visible.frame.origin.y - section.origin.y)
       let maxTop = max(visible.frame.origin.y, section.origin.y)
       let maxLeft = max(visible.frame.origin.x, section.origin.x)
-      let minBottom = min(visible.frame.origin.y + visible.frame.size.height, section.origin.y + section.size.height)
-      let minRight = min(visible.frame.origin.x + visible.frame.size.width, section.origin.x + section.size.width)
+      let minBottom = min(visible.frame.maxY, section.maxY)
+      let minRight = min(visible.frame.maxX, section.maxX)
       let visibleFrameForCell = CGRect(x: x, y: y, width: minRight - maxLeft, height: minBottom - maxTop)
       let child = childSections[index]
       let childVisible = child.sectionData?.visible(for: visibleFrameForCell)


### PR DESCRIPTION
From commit messages: 

After this fix there is one more issue:

When a horizontal layout section with visible frame inset is inside a section provider with vertical layout (or the other way around) the visible frame inset is actually twice the set value. This is due to the optimised index search not checking vertical position. Right now I added a guard to not show the section when visible frame is empty instead of when there is no frames inside the visibleFrame. Not sure if this is better optimised or not.

We can't really fix this since we can't actually check if the insets are in the right direction because the VisibleFrameInsetLayout might get transposed after checking. 