### PR TITLE
fix Crash detail:

### DIFF
--- a/Sources/Other/CollectionReuseViewManager.swift
+++ b/Sources/Other/CollectionReuseViewManager.swift
@@ -40,6 +40,9 @@ public class CollectionReuseViewManager: NSObject {
     } else {
       reusableViews[identifier] = [view]
     }
+    if let collectionView = view as? CollectionView {
+      collectionView.provider = nil
+    }
     if let cleanupTimer = cleanupTimer {
       cleanupTimer.fireDate = Date().addingTimeInterval(lifeSpan)
     } else {

--- a/Sources/Provider/FlattenedProvider.swift
+++ b/Sources/Provider/FlattenedProvider.swift
@@ -70,7 +70,7 @@ struct FlattenedProvider: ItemProvider {
   func identifier(at: Int) -> String {
     let (sectionIndex, item) = indexPath(at)
     if let sectionData = childSections[sectionIndex].sectionData {
-      return provider.identifier(at: sectionIndex) + sectionData.identifier(at: item)
+      return provider.identifier(at: sectionIndex) + "-" + sectionData.identifier(at: item)
     } else {
       return provider.identifier(at: sectionIndex)
     }


### PR DESCRIPTION
Fix: when CollectionView goto Reuse pool，need to set its provider = nil，otherwise there may be two collectionView have the same provider，and maybe will crash later.
Fix：当CollectionView进入复用池，需要重置provider，避免出现 多个collectionView 持有同个provider对象，导致数据更新不同步，进而未同步的collectionView中flattenProvider的childSections范围错误导致越界崩溃